### PR TITLE
feat: Add support for writing parquet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,19 +5,25 @@ edition = "2021"
 license = "Apache-2.0"
 description = "Pure Rust Iceberg Implementation"
 
+
 [features]
 arrow_schema = ["dep:arrow-schema"]
+io_parquet = ["arrow_schema","dep:parquet","dep:arrow-array"]
 
 [dependencies]
 anyhow = "1"
+async-trait = "0.1.68"
 apache-avro = { version = "0.14", features = ["derive"] }
-arrow-schema = { version = ">=40", optional = true }
+arrow-array = { version = ">=40" , optional = true }
+arrow-schema = { version = ">=40" , optional = true }
+bytes = "1.4.0"
 futures = "0.3"
 opendal = "0.37"
 serde = "1"
 serde_json = "1"
 serde_with = "3"
 tokio = { version = "1.28", features = ["full"] }
+parquet = { version = ">=40", features = ["async"], optional = true }
 
 [[example]]
 name = "read_iceberg_table"

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "io_parquet")]
+pub mod parquet;

--- a/src/io/parquet.rs
+++ b/src/io/parquet.rs
@@ -1,0 +1,79 @@
+use anyhow::Result;
+use arrow_array::RecordBatch;
+use arrow_schema::SchemaRef;
+use opendal::{Operator, Writer};
+use parquet::{arrow::AsyncArrowWriter, file::properties::WriterProperties};
+
+pub struct ParquetWriter {
+    writer: AsyncArrowWriter<Writer>,
+}
+
+impl ParquetWriter {
+    /// Try to create a new Writer.
+    pub async fn try_new(
+        operator: Operator,
+        path: &str,
+        arrow_schema: SchemaRef,
+        props: Option<WriterProperties>,
+    ) -> Result<Self> {
+        let writer = operator.writer(path).await?;
+        Ok(ParquetWriter {
+            writer: AsyncArrowWriter::try_new(writer, arrow_schema, 0, props)?,
+        })
+    }
+
+    /// Append data into the file.
+    /// Note: It will not guarantee to take effect imediately.
+    pub async fn append(&mut self, data: &RecordBatch) -> Result<()> {
+        self.writer.write(data).await?;
+        Ok(())
+    }
+
+    /// Write footer ,flush rest data and close file.
+    /// Note: This function must be called before complete the write process.
+    pub async fn flush_and_close(self) -> Result<()> {
+        self.writer.close().await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use arrow_array::{ArrayRef, Int64Array, RecordBatch};
+    use bytes::Bytes;
+    use opendal::{services::Memory, Operator};
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+    use std::sync::Arc;
+
+    use crate::io::parquet::ParquetWriter;
+
+    #[tokio::test]
+    async fn parquet_append_test() -> Result<()> {
+        let mut builder = Memory::default();
+        builder.root("/tmp");
+        let op: Operator = Operator::new(builder)?.finish();
+
+        let col = Arc::new(Int64Array::from_iter_values(vec![1; 1024])) as ArrayRef;
+        let to_write = RecordBatch::try_from_iter([("col", col)]).unwrap();
+
+        let mut appender =
+            ParquetWriter::try_new(op.clone(), "/tmp/test", to_write.schema(), None).await?;
+        appender.append(&to_write).await?;
+        appender.append(&to_write).await?;
+        appender.flush_and_close().await?;
+
+        let res = op.read("/tmp/test").await?;
+        let res = Bytes::from(res);
+        let mut reader = ParquetRecordBatchReaderBuilder::try_new(res)
+            .unwrap()
+            .build()
+            .unwrap();
+        let res = reader.next().unwrap().unwrap();
+        assert_eq!(to_write, res);
+        let res = reader.next().unwrap().unwrap();
+        assert_eq!(to_write, res);
+
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,5 @@ pub mod types;
 
 mod table;
 pub use table::Table;
+
+pub mod io;


### PR DESCRIPTION
related issue: #37

This PR have two things needed to discussion now:
1. The `flush_and_close` interface. [In parquet, it used to write footer.](https://arrow.apache.org/rust/parquet/arrow/index.html#example-of-writing-arrow-record-batch-to-parquet-file:~:text=//%20writer%20must%20be%20closed%20to%20write%20footer%0A%20writer.close().unwrap()%3B) Not sure whether it can be a general interface in FileAppender. But seems it can't be avoid if we reuse [parquet](https://arrow.apache.org/rust/parquet/arrow/index.html.).

2. Can we cancel arrow_schema optional? Because we need to use it in parquet appender. 

@liurenjie1024 @Xuanwo 
