### PR TITLE
feat: support data file location generator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ arrow-schema = { version = ">=40", optional = true }
 bytes = "1.4.0"
 futures = "0.3"
 opendal = "0.37"
+uuid = { version = "1", features = ["v4"] }
 serde = "1"
 serde_json = "1"
 serde_with = "3"

--- a/src/io/location_generator.rs
+++ b/src/io/location_generator.rs
@@ -1,0 +1,216 @@
+use std::str::FromStr;
+use std::sync::atomic::AtomicUsize;
+
+use crate::types::{DataFileFormat, TableMetadata};
+use crate::{Error, ErrorKind, Result};
+use uuid::Uuid;
+
+/// TODO: move to table_properties.rs
+const DEFAULT_FILE_FORMAT: &str = "write.format.default";
+const DEFAULT_FILE_FORMAT_DEFAULT: &str = "parquet";
+const WRITE_DATA_LOCATION: &str = "write.data.path";
+const WRITE_FOLDER_STORAGE_LOCATION: &str = "write.folder-storage.path";
+
+pub struct DataFileLocationGenerator {
+    file_count: AtomicUsize,
+    partition_id: usize,
+    task_id: usize,
+    operation_id: String,
+    file_format: DataFileFormat,
+    suffix: Option<String>,
+    /// The data file relpath related to the base of table location.
+    data_rel_location: String,
+}
+
+impl DataFileLocationGenerator {
+    pub fn try_new(
+        table_metatdata: TableMetadata,
+        partition_id: usize,
+        task_id: usize,
+        suffix: Option<String>,
+    ) -> Result<Self> {
+        let operation_id = Uuid::new_v4().to_string();
+
+        let file_format = DataFileFormat::from_str(
+            &table_metatdata
+                .properties
+                .as_ref()
+                .and_then(|prop| prop.get(DEFAULT_FILE_FORMAT))
+                .cloned()
+                .unwrap_or(DEFAULT_FILE_FORMAT_DEFAULT.to_string()),
+        )
+        .unwrap_or(DataFileFormat::Parquet);
+
+        let data_rel_location = {
+            let base_location = &table_metatdata.location;
+            let data_location = &table_metatdata.properties.and_then(|prop| {
+                prop.get(WRITE_DATA_LOCATION)
+                    .or(prop.get(WRITE_FOLDER_STORAGE_LOCATION))
+                    .cloned()
+            });
+            if let Some(data_location) = data_location {
+                data_location
+                    .strip_prefix(base_location)
+                    .ok_or(Error::new(
+                        ErrorKind::IcebergDataInvalid,
+                        format!(
+                            "data location {} is not a subpath of table location {}",
+                            data_location, base_location
+                        ),
+                    ))?
+                    .to_string()
+            } else {
+                "data".to_string()
+            }
+        };
+
+        Ok(Self {
+            file_count: AtomicUsize::new(0),
+            partition_id,
+            task_id,
+            operation_id,
+            file_format,
+            suffix,
+            data_rel_location,
+        })
+    }
+
+    /// Generate a related file location for the writer.
+    ///
+    /// # TODO
+    ///
+    /// - Only support to generate file name for unpartitioned write.
+    /// - May need a way(e.g LocationProvider) to generate custom file name in future. It's useful in some case: https://github.com/apache/iceberg/issues/1911.
+    pub fn generate_name(&self) -> String {
+        let suffix = if let Some(suffix) = &self.suffix {
+            format!("-{}", suffix)
+        } else {
+            "".to_string()
+        };
+
+        let file_name = format!(
+            "{:05}-{}-{}-{:05}{}",
+            self.partition_id,
+            self.task_id,
+            self.operation_id,
+            self.file_count
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+            suffix
+        );
+
+        let extension = self.file_format.to_string();
+        let file_name = if file_name.to_ascii_lowercase().ends_with(&extension) {
+            file_name
+        } else {
+            format!("{}.{}", file_name, extension)
+        };
+
+        format!("{}/{}", self.data_rel_location, file_name)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{collections::HashMap, env, fs};
+
+    use anyhow::Result;
+
+    use crate::{
+        io::location_generator::{
+            DataFileLocationGenerator, WRITE_DATA_LOCATION, WRITE_FOLDER_STORAGE_LOCATION,
+        },
+        types::parse_table_metadata,
+    };
+
+    #[tokio::test]
+    async fn test_location_generator_default() -> Result<()> {
+        let metadata = {
+            let path = format!(
+                "{}/testdata/simple_table/metadata/v1.metadata.json",
+                env::current_dir()
+                    .expect("current_dir must exist")
+                    .to_string_lossy()
+            );
+
+            let bs = fs::read(path).expect("read_file must succeed");
+
+            parse_table_metadata(&bs).expect("parse_table_metadata v1 must succeed")
+        };
+
+        let generator = DataFileLocationGenerator::try_new(metadata, 0, 0, None)?;
+        let name = generator.generate_name();
+        assert!(name.starts_with("data/"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_location_generator_with_write_data_location() -> Result<()> {
+        let mut metadata = {
+            let path = format!(
+                "{}/testdata/simple_table/metadata/v1.metadata.json",
+                env::current_dir()
+                    .expect("current_dir must exist")
+                    .to_string_lossy()
+            );
+
+            let bs = fs::read(path).expect("read_file must succeed");
+
+            parse_table_metadata(&bs).expect("parse_table_metadata v1 must succeed")
+        };
+
+        // Mock metadata to test
+        metadata.location = "/tmp/table".to_string();
+        let mock_properties = {
+            let mut map = HashMap::new();
+            map.insert(
+                WRITE_DATA_LOCATION.to_string(),
+                "/tmp/table/mock".to_string(),
+            );
+            map.insert(
+                WRITE_FOLDER_STORAGE_LOCATION.to_string(),
+                "/tmp/table/mock_storage".to_string(),
+            );
+            map
+        };
+        metadata.properties = Some(mock_properties);
+
+        let generator = DataFileLocationGenerator::try_new(metadata, 0, 0, None)?;
+        let name = generator.generate_name();
+        assert!(name.starts_with("/mock"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_location_generator_with_write_folder_storage_location() -> Result<()> {
+        let mut metadata = {
+            let path = format!(
+                "{}/testdata/simple_table/metadata/v1.metadata.json",
+                env::current_dir()
+                    .expect("current_dir must exist")
+                    .to_string_lossy()
+            );
+
+            let bs = fs::read(path).expect("read_file must succeed");
+
+            parse_table_metadata(&bs).expect("parse_table_metadata v1 must succeed")
+        };
+
+        // Mock metadata to test
+        metadata.location = "/tmp/table".to_string();
+        let mock_properties = {
+            let mut map = HashMap::new();
+            map.insert(
+                WRITE_FOLDER_STORAGE_LOCATION.to_string(),
+                "/tmp/table/mock_storage".to_string(),
+            );
+            map
+        };
+        metadata.properties = Some(mock_properties);
+
+        let generator = DataFileLocationGenerator::try_new(metadata, 0, 0, None)?;
+        let name = generator.generate_name();
+        assert!(name.starts_with("/mock_storage"));
+        Ok(())
+    }
+}

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,2 +1,3 @@
+pub mod location_generator;
 #[cfg(feature = "io_parquet")]
 pub mod parquet;

--- a/src/types/in_memory.rs
+++ b/src/types/in_memory.rs
@@ -1,6 +1,10 @@
 //! in_memory module provides the definition of iceberg in-memory data types.
 
-use std::collections::HashMap;
+use std::{collections::HashMap, str::FromStr};
+
+use crate::Error;
+use crate::ErrorKind;
+use crate::Result;
 
 /// All data types are either primitives or nested types, which are maps, lists, or structs.
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -655,6 +659,33 @@ pub enum DataFileFormat {
     Avro,
     Orc,
     Parquet,
+}
+
+impl FromStr for DataFileFormat {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s.to_lowercase().as_str() {
+            "avro" => Ok(Self::Avro),
+            "orc" => Ok(Self::Orc),
+            "parquet" => Ok(Self::Parquet),
+            _ => Err(Error::new(
+                ErrorKind::IcebergFeatureUnsupported,
+                format!("Unsupported data file format: {}", s),
+            )),
+        }
+    }
+}
+
+impl ToString for DataFileFormat {
+    fn to_string(&self) -> String {
+        match self {
+            DataFileFormat::Avro => "avro",
+            DataFileFormat::Orc => "orc",
+            DataFileFormat::Parquet => "parquet",
+        }
+        .to_string()
+    }
 }
 
 /// Snapshot of contains all data of a table at a point in time.

--- a/src/types/on_disk/manifest_file.rs
+++ b/src/types/on_disk/manifest_file.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::str::FromStr;
 
 use apache_avro::from_value;
 use apache_avro::Reader;
@@ -241,15 +242,7 @@ fn parse_data_content_type(v: i32) -> Result<types::DataContentType> {
 }
 
 fn parse_data_file_format(s: &str) -> Result<types::DataFileFormat> {
-    match s.to_lowercase().as_str() {
-        "avro" => Ok(types::DataFileFormat::Avro),
-        "orc" => Ok(types::DataFileFormat::Orc),
-        "parquet" => Ok(types::DataFileFormat::Parquet),
-        v => Err(Error::new(
-            ErrorKind::IcebergFeatureUnsupported,
-            format!("data file format {:?} is not supported", v),
-        )),
-    }
+    types::DataFileFormat::from_str(s)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
To impl #38, we need to implement a data file location generator first. It used to generate the relpath of a data file used by opendal.

This PR implement a simple version of it.