### PR TITLE
feat: support open_with_operator

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -78,6 +78,13 @@ impl Table {
         Ok(table)
     }
 
+    /// Open an iceberg table by operator
+    pub async fn open_with_op(op: Operator) -> Result<Table> {
+        let mut table = Table::new(op);
+        table.load().await?;
+        Ok(table)
+    }
+
     /// Fetch current table metadata.
     pub fn current_table_metadata(&self) -> Result<&types::TableMetadata> {
         if self.current_version == 0 {


### PR DESCRIPTION
I try to using Table in RisingWave and find that use uri to create table is not convinient.

For example, load a table using s3, we get the config like 
```
struct config {
    path: &str,
    access_key: &str,
    endpoint: &str
}
```
If we only support to create table using uri, we need to serialize the config into uri and deserialize in icelake.

So in this case, may be having a `open_with_operator` is better. 

How do you think? @liurenjie1024 @Xuanwo 