### PR TITLE
fix: Rename some data structures.

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -214,7 +214,7 @@ impl Table {
             self.task_id,
             None,
         )
-            .await?;
+        .await?;
         self.task_id += 1;
         Ok(task_writer)
     }

--- a/src/table.rs
+++ b/src/table.rs
@@ -9,6 +9,7 @@ use opendal::Operator;
 
 use crate::io::task_writer::TaskWriter;
 use crate::types;
+use crate::types::DataFile;
 
 /// Table is the main entry point for the IceLake.
 pub struct Table {
@@ -119,11 +120,15 @@ impl Table {
         let manifest_list_content = self.op.read(&manifest_list_path).await?;
         let manifest_list = types::parse_manifest_list(&manifest_list_content)?;
 
-        let manifest_path = self.rel_path(&manifest_list.manifest_path)?;
-        let manifest_content = self.op.read(&manifest_path).await?;
-        let (_, manifest_files) = types::parse_manifest_file(&manifest_content)?;
+        let mut data_files: Vec<DataFile> = Vec::new();
+        for manifest_list_entry in manifest_list.entries {
+            let manifest_path = self.rel_path(&manifest_list_entry.manifest_path)?;
+            let manifest_content = self.op.read(&manifest_path).await?;
+            let manifest = types::parse_manifest_file(&manifest_content)?;
+            data_files.extend(manifest.entries.into_iter().map(|v| v.data_file));
+        }
 
-        Ok(manifest_files.into_iter().map(|v| v.data_file).collect())
+        Ok(data_files)
     }
 
     /// Get the relpath related to the base of table location.
@@ -209,7 +214,7 @@ impl Table {
             self.task_id,
             None,
         )
-        .await?;
+            .await?;
         self.task_id += 1;
         Ok(task_writer)
     }

--- a/src/types/in_memory.rs
+++ b/src/types/in_memory.rs
@@ -450,6 +450,13 @@ pub enum NullOrder {
 /// manifest.
 #[derive(Debug, PartialEq, Clone)]
 pub struct ManifestList {
+    /// Entries in a manifest list.
+    pub entries: Vec<ManifestListEntry>,
+}
+
+/// Entry in a manifest list.
+#[derive(Debug, PartialEq, Clone)]
+pub struct ManifestListEntry {
     /// field: 500
     ///
     /// Location of the manifest file
@@ -547,7 +554,7 @@ pub struct FieldSummary {
 /// files, along with each file’s partition data tuple, metrics, and tracking
 /// information.
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct ManifestFile {
+pub struct ManifestEntry {
     /// field: 0
     ///
     /// Used to track additions and deletions.
@@ -593,6 +600,15 @@ pub struct ManifestMetadata {
     pub format_version: i32,
     /// Type of content files tracked by the manifest: “data” or “deletes”
     pub content: ManifestContentType,
+}
+
+/// A manifest contains metadata and a list of entries.
+#[derive(Debug, PartialEq, Clone)]
+pub struct ManifestFile {
+    /// Metadata of a manifest file.
+    pub metadata: ManifestMetadata,
+    /// Entries in manifest file.
+    pub entries: Vec<ManifestEntry>,
 }
 
 /// Type of content files tracked by the manifest

--- a/src/types/on_disk/manifest_file.rs
+++ b/src/types/on_disk/manifest_file.rs
@@ -16,7 +16,7 @@ use crate::Result;
 /// Parse manifest file from avro bytes.
 pub fn parse_manifest_file(
     bs: &[u8],
-) -> Result<(types::ManifestMetadata, Vec<types::ManifestFile>)> {
+) -> Result<types::ManifestFile> {
     let reader = Reader::new(bs)?;
 
     // Parse manifest metadata
@@ -38,7 +38,7 @@ pub fn parse_manifest_file(
                             ErrorKind::IcebergDataInvalid,
                             format!("schema-id {:?} is invalid", v),
                         )
-                        .set_source(err)
+                            .set_source(err)
                     })?
                 }
             }
@@ -53,7 +53,7 @@ pub fn parse_manifest_file(
                             ErrorKind::IcebergDataInvalid,
                             format!("partition-spec-id {:?} is invalid", v),
                         )
-                        .set_source(err)
+                            .set_source(err)
                     })?
                 }
             }
@@ -68,7 +68,7 @@ pub fn parse_manifest_file(
                             ErrorKind::IcebergDataInvalid,
                             format!("format-version {:?} is invalid", v),
                         )
-                        .set_source(err)
+                            .set_source(err)
                     })?
                 }
             }
@@ -83,7 +83,7 @@ pub fn parse_manifest_file(
                             ErrorKind::IcebergDataInvalid,
                             format!("partition-spec-id {:?} is invalid", v),
                         )
-                        .set_source(err)
+                            .set_source(err)
                     })?
                 }
             };
@@ -95,25 +95,25 @@ pub fn parse_manifest_file(
                     return Err(Error::new(
                         ErrorKind::IcebergDataInvalid,
                         format!("content type {} is invalid", c),
-                    ))
+                    ));
                 }
             }
         },
     };
 
     // Parse manifest entries
-    let mut entries = Vec::new();
+    let mut entries = Vec::<types::ManifestEntry>::new();
     for value in reader {
         let v = value?;
-        entries.push(from_value::<ManifestFile>(&v)?.try_into()?);
+        entries.push(from_value::<ManifestEntry>(&v)?.try_into()?);
     }
 
-    Ok((metadata, entries))
+    Ok(types::ManifestFile { metadata, entries })
 }
 
 #[derive(Deserialize)]
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
-struct ManifestFile {
+struct ManifestEntry {
     status: i32,
     snapshot_id: Option<i64>,
     sequence_number: Option<i64>,
@@ -121,11 +121,11 @@ struct ManifestFile {
     data_file: DataFile,
 }
 
-impl TryFrom<ManifestFile> for types::ManifestFile {
+impl TryFrom<ManifestEntry> for types::ManifestEntry {
     type Error = Error;
 
-    fn try_from(v: ManifestFile) -> Result<Self> {
-        Ok(types::ManifestFile {
+    fn try_from(v: ManifestEntry) -> Result<Self> {
+        Ok(types::ManifestEntry {
             status: parse_manifest_status(v.status)?,
             snapshot_id: v.snapshot_id,
             sequence_number: v.sequence_number,
@@ -253,6 +253,7 @@ mod tests {
     use anyhow::Result;
     use apache_avro::from_value;
     use apache_avro::Reader;
+    use crate::types::ManifestFile;
 
     use super::*;
 
@@ -283,7 +284,7 @@ mod tests {
         let mut entries = Vec::new();
         for value in reader {
             let v = value?;
-            entries.push(from_value::<ManifestFile>(&v)?);
+            entries.push(from_value::<ManifestEntry>(&v)?);
         }
 
         assert_eq!(entries.len(), 3);
@@ -301,10 +302,10 @@ mod tests {
 
         let bs = fs::read(path).expect("read_file must succeed");
 
-        let (meta, manifests) = parse_manifest_file(&bs)?;
+        let ManifestFile { metadata,  entries } = parse_manifest_file(&bs)?;
 
         assert_eq!(
-            meta,
+            metadata,
             types::ManifestMetadata {
                 schema: types::Schema {
                     schema_id: 0,
@@ -327,20 +328,20 @@ mod tests {
                             comment: None,
                             initial_default: None,
                             write_default: None,
-                        }
-                    ]
+                        },
+                    ],
                 },
                 schema_id: 0,
                 partition_spec_id: 0,
                 format_version: 1,
-                content: types::ManifestContentType::Data
+                content: types::ManifestContentType::Data,
             }
         );
 
-        assert_eq!(manifests.len(), 3);
-        assert_eq!(manifests[0].data_file.file_path, "/opt/bitnami/spark/warehouse/db/table/data/00000-0-b8982382-f016-467a-84e4-5e6bbe0ff19a-00001.parquet");
-        assert_eq!(manifests[1].data_file.file_path, "/opt/bitnami/spark/warehouse/db/table/data/00001-1-b8982382-f016-467a-84e4-5e6bbe0ff19a-00001.parquet");
-        assert_eq!(manifests[2].data_file.file_path, "/opt/bitnami/spark/warehouse/db/table/data/00002-2-b8982382-f016-467a-84e4-5e6bbe0ff19a-00001.parquet");
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].data_file.file_path, "/opt/bitnami/spark/warehouse/db/table/data/00000-0-b8982382-f016-467a-84e4-5e6bbe0ff19a-00001.parquet");
+        assert_eq!(entries[1].data_file.file_path, "/opt/bitnami/spark/warehouse/db/table/data/00001-1-b8982382-f016-467a-84e4-5e6bbe0ff19a-00001.parquet");
+        assert_eq!(entries[2].data_file.file_path, "/opt/bitnami/spark/warehouse/db/table/data/00002-2-b8982382-f016-467a-84e4-5e6bbe0ff19a-00001.parquet");
 
         Ok(())
     }

--- a/src/types/on_disk/manifest_file.rs
+++ b/src/types/on_disk/manifest_file.rs
@@ -14,9 +14,7 @@ use crate::ErrorKind;
 use crate::Result;
 
 /// Parse manifest file from avro bytes.
-pub fn parse_manifest_file(
-    bs: &[u8],
-) -> Result<types::ManifestFile> {
+pub fn parse_manifest_file(bs: &[u8]) -> Result<types::ManifestFile> {
     let reader = Reader::new(bs)?;
 
     // Parse manifest metadata
@@ -38,7 +36,7 @@ pub fn parse_manifest_file(
                             ErrorKind::IcebergDataInvalid,
                             format!("schema-id {:?} is invalid", v),
                         )
-                            .set_source(err)
+                        .set_source(err)
                     })?
                 }
             }
@@ -53,7 +51,7 @@ pub fn parse_manifest_file(
                             ErrorKind::IcebergDataInvalid,
                             format!("partition-spec-id {:?} is invalid", v),
                         )
-                            .set_source(err)
+                        .set_source(err)
                     })?
                 }
             }
@@ -68,7 +66,7 @@ pub fn parse_manifest_file(
                             ErrorKind::IcebergDataInvalid,
                             format!("format-version {:?} is invalid", v),
                         )
-                            .set_source(err)
+                        .set_source(err)
                     })?
                 }
             }
@@ -83,7 +81,7 @@ pub fn parse_manifest_file(
                             ErrorKind::IcebergDataInvalid,
                             format!("partition-spec-id {:?} is invalid", v),
                         )
-                            .set_source(err)
+                        .set_source(err)
                     })?
                 }
             };
@@ -250,10 +248,10 @@ mod tests {
     use std::env;
     use std::fs;
 
+    use crate::types::ManifestFile;
     use anyhow::Result;
     use apache_avro::from_value;
     use apache_avro::Reader;
-    use crate::types::ManifestFile;
 
     use super::*;
 
@@ -302,7 +300,7 @@ mod tests {
 
         let bs = fs::read(path).expect("read_file must succeed");
 
-        let ManifestFile { metadata,  entries } = parse_manifest_file(&bs)?;
+        let ManifestFile { metadata, entries } = parse_manifest_file(&bs)?;
 
         assert_eq!(
             metadata,

--- a/src/types/on_disk/manifest_list.rs
+++ b/src/types/on_disk/manifest_list.rs
@@ -3,10 +3,10 @@ use apache_avro::Reader;
 use serde::Deserialize;
 
 use crate::types;
+use crate::types::ManifestList;
 use crate::Error;
 use crate::ErrorKind;
 use crate::Result;
-use crate::types::ManifestList;
 
 /// Parse manifest list from json bytes.
 ///
@@ -14,7 +14,16 @@ use crate::types::ManifestList;
 pub fn parse_manifest_list(bs: &[u8]) -> Result<ManifestList> {
     // Parse manifest entries
     let entries = Reader::new(bs)?
-        .map(|v| v.and_then(|value| from_value::<ManifestListEntry>(&value)).map_err(|e| Error::new(ErrorKind::IcebergDataInvalid, "Failed to parse manifest list entry").set_source(e)))
+        .map(|v| {
+            v.and_then(|value| from_value::<ManifestListEntry>(&value))
+                .map_err(|e| {
+                    Error::new(
+                        ErrorKind::IcebergDataInvalid,
+                        "Failed to parse manifest list entry",
+                    )
+                    .set_source(e)
+                })
+        })
         .map(|v| v.and_then(types::ManifestListEntry::try_from))
         .collect::<Result<Vec<_>>>()?;
 


### PR DESCRIPTION
This pr rename some data structures to better align to iceberg spec.

1. Add a struct `ManifestList`
2. Rename `ManifestList` to `ManifestListEntry`
3. Add a struct `ManifestFile`
4. Rename `ManifestFile` to `ManifestEntry`