### PR TITLE
Add manifest writer tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ lazy_static = "1.4"
 
 [dev-dependencies]
 once_cell = "1"
+tempfile = "3"
 
 [[example]]
 name = "read_iceberg_table"

--- a/src/io/data_file_writer.rs
+++ b/src/io/data_file_writer.rs
@@ -183,11 +183,13 @@ impl DataFileWriter {
             /// - `file_size_in_bytes` can't get from `FileMetaData` now.
             /// - `file_offset` in `FileMetaData` always be None now.
             /// - `nan_value_counts` can't get from `FileMetaData` now.
-            split_offsets: Some(meta_data
-                .row_groups
-                .iter()
-                .filter_map(|group| group.file_offset)
-                .collect()),
+            split_offsets: Some(
+                meta_data
+                    .row_groups
+                    .iter()
+                    .filter_map(|group| group.file_offset)
+                    .collect(),
+            ),
             nan_value_counts: None,
             lower_bounds: None,
             upper_bounds: None,

--- a/src/io/data_file_writer.rs
+++ b/src/io/data_file_writer.rs
@@ -122,7 +122,7 @@ impl DataFileWriter {
     ///
     /// This function may be refactor when we support more file format.
     fn convert_meta_to_datafile(&self, meta_data: FileMetaData, written_size: u64) -> DataFile {
-        let (column_sizes, value_counts, null_value_counts, _distinct_counts) = {
+        let (column_sizes, value_counts, null_value_counts, distinct_counts) = {
             // how to decide column id
             let mut per_col_size: HashMap<i32, _> = HashMap::new();
             let mut per_col_val_num: HashMap<i32, _> = HashMap::new();
@@ -174,6 +174,7 @@ impl DataFileWriter {
             column_sizes: Some(column_sizes),
             value_counts: Some(value_counts),
             null_value_counts: Some(null_value_counts),
+            distinct_counts: Some(distinct_counts),
             key_metadata: meta_data.footer_signing_key_metadata,
             file_size_in_bytes: written_size as i64,
             /// # TODO

--- a/src/io/data_file_writer.rs
+++ b/src/io/data_file_writer.rs
@@ -122,7 +122,7 @@ impl DataFileWriter {
     ///
     /// This function may be refactor when we support more file format.
     fn convert_meta_to_datafile(&self, meta_data: FileMetaData, written_size: u64) -> DataFile {
-        let (column_sizes, value_counts, null_value_counts, distinct_counts) = {
+        let (column_sizes, value_counts, null_value_counts, _distinct_counts) = {
             // how to decide column id
             let mut per_col_size: HashMap<i32, _> = HashMap::new();
             let mut per_col_val_num: HashMap<i32, _> = HashMap::new();
@@ -174,7 +174,6 @@ impl DataFileWriter {
             column_sizes: Some(column_sizes),
             value_counts: Some(value_counts),
             null_value_counts: Some(null_value_counts),
-            distinct_counts: Some(distinct_counts),
             key_metadata: meta_data.footer_signing_key_metadata,
             file_size_in_bytes: written_size as i64,
             /// # TODO
@@ -183,11 +182,11 @@ impl DataFileWriter {
             /// - `file_size_in_bytes` can't get from `FileMetaData` now.
             /// - `file_offset` in `FileMetaData` always be None now.
             /// - `nan_value_counts` can't get from `FileMetaData` now.
-            split_offsets: meta_data
+            split_offsets: Some(meta_data
                 .row_groups
                 .iter()
                 .filter_map(|group| group.file_offset)
-                .collect(),
+                .collect()),
             nan_value_counts: None,
             lower_bounds: None,
             upper_bounds: None,

--- a/src/types/in_memory.rs
+++ b/src/types/in_memory.rs
@@ -939,6 +939,15 @@ pub struct DataFile {
     ///
     /// Map from column id to number of NaN values in the column
     pub nan_value_counts: Option<HashMap<i32, i64>>,
+    /// field id: 111
+    /// key field id: 123
+    /// value field id: 124
+    ///
+    /// Map from column id to number of distinct values in the column;
+    /// distinct counts must be derived using values in the file by counting
+    /// or using sketches, but not using methods like merging existing
+    /// distinct counts
+    pub distinct_counts: Option<HashMap<i32, i64>>,
     /// field id: 125
     /// key field id: 126
     /// value field id: 127
@@ -1144,6 +1153,7 @@ impl DataFile {
             value_counts: None,
             null_value_counts: None,
             nan_value_counts: None,
+            distinct_counts: None,
             lower_bounds: None,
             upper_bounds: None,
             key_metadata: None,

--- a/src/types/in_memory.rs
+++ b/src/types/in_memory.rs
@@ -1144,6 +1144,34 @@ impl DataFile {
         Field::required(102, "partition", Any::Struct(partition_type))
             .with_comment("Partition data tuple, schema based on the partition spec")
     }
+
+    pub fn new(
+        content: DataContentType,
+        file_path: impl Into<String>,
+        file_format: DataFileFormat,
+        record_count: i64,
+        file_size_in_bytes: i64,
+    ) -> Self {
+        Self {
+            content,
+            file_path,
+            file_format,
+            partition: (),
+            record_count,
+            file_size_in_bytes,
+            column_sizes: None,
+            value_counts: None,
+            null_value_counts: None,
+            nan_value_counts: None,
+            distinct_counts: None,
+            lower_bounds: None,
+            upper_bounds: None,
+            key_metadata: None,
+            split_offsets: vec![],
+            equality_ids: None,
+            sort_order_id: None,
+        }
+    }
 }
 
 /// Type of content stored by the data file: data, equality deletes, or

--- a/src/types/in_memory.rs
+++ b/src/types/in_memory.rs
@@ -1145,7 +1145,7 @@ impl DataFile {
             .with_comment("Partition data tuple, schema based on the partition spec")
     }
 
-    pub fn new(
+    pub(crate) fn new(
         content: DataContentType,
         file_path: impl Into<String>,
         file_format: DataFileFormat,
@@ -1154,7 +1154,7 @@ impl DataFile {
     ) -> Self {
         Self {
             content,
-            file_path,
+            file_path: file_path.into(),
             file_format,
             partition: (),
             record_count,

--- a/src/types/on_disk/manifest_file.rs
+++ b/src/types/on_disk/manifest_file.rs
@@ -12,10 +12,8 @@ use serde_with::Bytes;
 use super::parse_schema;
 use crate::types;
 use crate::types::on_disk::partition_spec::PartitionSpec;
-use crate::types::on_disk::schema::Schema;
-use crate::types::{
-    DataContentType, ManifestContentType, ManifestFile, ManifestListEntry, UNASSIGNED_SEQ_NUM,
-};
+use crate::types::on_disk::schema::serialize_schema;
+use crate::types::{DataContentType, ManifestFile, ManifestListEntry, UNASSIGNED_SEQ_NUM};
 use crate::types::{ManifestStatus, TableFormatVersion};
 use crate::Error;
 use crate::ErrorKind;
@@ -117,14 +115,6 @@ pub fn parse_manifest_file(bs: &[u8]) -> Result<types::ManifestFile> {
     }
 
     Ok(types::ManifestFile { metadata, entries })
-}
-
-/// Save manifest file.
-pub fn write_manifest_file() -> Result<ManifestListEntry> {
-    Err(Error::new(
-        ErrorKind::IcebergFeatureUnsupported,
-        "Write manifest file!",
-    ))
 }
 
 #[derive(Serialize, Deserialize)]
@@ -295,11 +285,13 @@ fn parse_data_file_format(s: &str) -> Result<types::DataFileFormat> {
     types::DataFileFormat::from_str(s)
 }
 
-struct ManifestWriter {
-    content_type: ManifestContentType,
-    table_schema: types::Schema,
+/// Manifest writer to write manifest to file.
+pub(crate) struct ManifestWriter {
     partition_spec: types::PartitionSpec,
+    op: Operator,
+    // Output path relative to operator root.
     output_path: String,
+    snapshot_id: i64,
 
     added_files: i64,
     added_rows: i64,
@@ -308,11 +300,31 @@ struct ManifestWriter {
     deleted_files: i64,
     deleted_rows: i64,
     min_seq_num: Option<i64>,
-    snapshot_id: i64,
-    op: Operator,
 }
 
 impl ManifestWriter {
+    pub fn new(
+        partition_spec: types::PartitionSpec,
+        op: Operator,
+        output_path: impl Into<String>,
+        snapshot_id: i64,
+    ) -> Self {
+        Self {
+            partition_spec,
+            op,
+            output_path: output_path.into(),
+            snapshot_id,
+
+            added_files: 0,
+            added_rows: 0,
+            existing_files: 0,
+            existing_rows: 0,
+            deleted_files: 0,
+            deleted_rows: 0,
+            min_seq_num: None,
+        }
+    }
+
     pub async fn write(mut self, manifest: ManifestFile) -> Result<ManifestListEntry> {
         // A place holder for avro schema since avro writer needs its reference.
         let avro_schema;
@@ -322,14 +334,18 @@ impl ManifestWriter {
             .unwrap_or(TableFormatVersion::V1)
         {
             TableFormatVersion::V1 => {
-                let partition_type = self.partition_spec.partition_type(&self.table_schema)?;
+                let partition_type = self
+                    .partition_spec
+                    .partition_type(&manifest.metadata.schema)?;
                 avro_schema = AvroSchema::try_from(&ManifestFile::v1_schema(partition_type))?;
-                self.v1_writer(&avro_schema)?
+                self.v1_writer(&avro_schema, &manifest.metadata.schema)?
             }
             TableFormatVersion::V2 => {
-                let partition_type = self.partition_spec.partition_type(&self.table_schema)?;
-                avro_schema = AvroSchema::try_from(&ManifestFile::v1_schema(partition_type))?;
-                self.v2_writer(&avro_schema)?
+                let partition_type = self
+                    .partition_spec
+                    .partition_type(&manifest.metadata.schema)?;
+                avro_schema = AvroSchema::try_from(&ManifestFile::v2_schema(partition_type))?;
+                self.v2_writer(&avro_schema, &manifest.metadata.schema)?
             }
         };
 
@@ -371,10 +387,10 @@ impl ManifestWriter {
         self.op.write(self.output_path.as_str(), connect).await?;
 
         Ok(ManifestListEntry {
-            manifest_path: "".to_string(),
+            manifest_path: format!("{}/{}", self.op.info().root(), &self.output_path),
             manifest_length: length as i64,
             partition_spec_id: manifest.metadata.partition_spec_id,
-            content: self.content_type,
+            content: manifest.metadata.content,
             sequence_number: UNASSIGNED_SEQ_NUM,
             min_sequence_number: self.min_seq_num.unwrap_or(UNASSIGNED_SEQ_NUM),
             added_snapshot_id: self.snapshot_id,
@@ -389,12 +405,13 @@ impl ManifestWriter {
         })
     }
 
-    fn v1_writer<'a>(&self, avro_schema: &'a AvroSchema) -> Result<AvroWriter<'a, Vec<u8>>> {
+    fn v1_writer<'a>(
+        &self,
+        avro_schema: &'a AvroSchema,
+        table_schema: &types::Schema,
+    ) -> Result<AvroWriter<'a, Vec<u8>>> {
         let mut writer = AvroWriter::new(avro_schema, Vec::new());
-        writer.add_user_metadata(
-            "schema".to_string(),
-            serde_json::to_string(&Schema::try_from(&self.table_schema)?)?,
-        )?;
+        writer.add_user_metadata("schema".to_string(), serialize_schema(table_schema)?)?;
         writer.add_user_metadata(
             "partition-spec".to_string(),
             serde_json::to_string(&PartitionSpec::try_from(&self.partition_spec)?)?,
@@ -410,12 +427,13 @@ impl ManifestWriter {
         Ok(writer)
     }
 
-    fn v2_writer<'a>(&self, avro_schema: &'a AvroSchema) -> Result<AvroWriter<'a, Vec<u8>>> {
+    fn v2_writer<'a>(
+        &self,
+        avro_schema: &'a AvroSchema,
+        table_schema: &types::Schema,
+    ) -> Result<AvroWriter<'a, Vec<u8>>> {
         let mut writer = AvroWriter::new(avro_schema, Vec::new());
-        writer.add_user_metadata(
-            "schema".to_string(),
-            serde_json::to_string(&Schema::try_from(&self.table_schema)?)?,
-        )?;
+        writer.add_user_metadata("schema".to_string(), serialize_schema(table_schema)?)?;
         writer.add_user_metadata(
             "partition-spec".to_string(),
             serde_json::to_string(&PartitionSpec::try_from(&self.partition_spec)?)?,
@@ -438,11 +456,15 @@ impl ManifestWriter {
 mod tests {
     use std::env;
     use std::fs;
+    use std::fs::read;
 
     use crate::types::ManifestFile;
     use anyhow::Result;
     use apache_avro::from_value;
     use apache_avro::Reader;
+    use opendal::services::Fs;
+    use opendal::Builder;
+    use tempfile::TempDir;
 
     use super::*;
 
@@ -533,5 +555,101 @@ mod tests {
         assert_eq!(entries[2].data_file.file_path, "/opt/bitnami/spark/warehouse/db/table/data/00002-2-b8982382-f016-467a-84e4-5e6bbe0ff19a-00001.parquet");
 
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_read_write_manifest_file_v1() {
+        let manifest_file = types::ManifestFile {
+            metadata: types::ManifestMetadata {
+                schema: types::Schema {
+                    schema_id: 0,
+                    identifier_field_ids: None,
+                    fields: vec![
+                        types::Field {
+                            id: 1,
+                            name: "id".to_string(),
+                            required: false,
+                            field_type: types::Any::Primitive(types::Primitive::Long),
+                            comment: None,
+                            initial_default: None,
+                            write_default: None,
+                        },
+                        types::Field {
+                            id: 2,
+                            name: "data".to_string(),
+                            required: false,
+                            field_type: types::Any::Primitive(types::Primitive::String),
+                            comment: None,
+                            initial_default: None,
+                            write_default: None,
+                        },
+                    ],
+                },
+                schema_id: 0,
+                partition_spec_id: 0,
+                format_version: Some(TableFormatVersion::V1),
+                content: types::ManifestContentType::Data,
+            },
+            entries: vec![
+                types::ManifestEntry {
+                    status: types::ManifestStatus::Added,
+                    snapshot_id: Some(1),
+                    sequence_number: Some(2),
+                    file_sequence_number: Some(3),
+                    data_file: types::DataFile::new(
+                        types::DataContentType::Data,
+                        "/tmp/1.parquet",
+                        types::DataFileFormat::Parquet,
+                        100,
+                        200,
+                    ),
+                },
+                types::ManifestEntry {
+                    status: types::ManifestStatus::Existing,
+                    snapshot_id: Some(12),
+                    sequence_number: Some(12),
+                    file_sequence_number: Some(13),
+                    data_file: types::DataFile::new(
+                        types::DataContentType::Data,
+                        "/tmp/2.parquet",
+                        types::DataFileFormat::Parquet,
+                        100,
+                        200,
+                    ),
+                },
+            ],
+        };
+
+        check_manifest_file_serde(manifest_file).await
+    }
+
+    async fn check_manifest_file_serde(manifest_file: types::ManifestFile) {
+        let tmp_dir = TempDir::new().unwrap();
+        let filename = "test.avro";
+
+        let operator = {
+            let mut builder = Fs::default();
+            builder.root(tmp_dir.path());
+            Operator::new(builder).unwrap().finish()
+        };
+
+        let partition_spec = types::PartitionSpec {
+            spec_id: 3,
+            fields: vec![],
+        };
+
+        let mut writer = ManifestWriter::new(partition_spec, operator, filename, 3);
+        let manifest_list_entry = writer.write(manifest_file.clone()).await.unwrap();
+
+        assert_eq!(
+            tmp_dir.path().join(filename),
+            manifest_list_entry.manifest_path
+        );
+        assert_eq!(manifest_file.metadata.content, manifest_list_entry.content);
+
+        let restored_manifest_file =
+            { parse_manifest_file(&read(tmp_dir.path().join(filename)).unwrap()).unwrap() };
+
+        assert_eq!(manifest_file, restored_manifest_file);
     }
 }

--- a/src/types/on_disk/manifest_file.rs
+++ b/src/types/on_disk/manifest_file.rs
@@ -424,8 +424,8 @@ mod tests {
     use std::fs::{canonicalize, read};
 
     use anyhow::Result;
-    use apache_avro::Reader;
     use apache_avro::from_value;
+    use apache_avro::Reader;
     use opendal::services::Fs;
     use tempfile::TempDir;
 

--- a/src/types/to_avro.rs
+++ b/src/types/to_avro.rs
@@ -55,7 +55,6 @@ impl<'a> TryFrom<&'a Field> for AvroRecordField {
                 }
                 avro_schema
             }
-
         };
 
         Ok(AvroRecordField {

--- a/src/types/to_avro.rs
+++ b/src/types/to_avro.rs
@@ -3,9 +3,14 @@
 use crate::error::Result;
 use crate::types::in_memory::{Any, Field, Primitive, Schema};
 use crate::{Error, ErrorKind};
-use apache_avro::schema::{Name, RecordField as AvroRecordField, RecordFieldOrder, RecordSchema};
+use apache_avro::schema::{
+    Name, RecordField as AvroRecordField, RecordFieldOrder, RecordSchema as AvroRecordSchema,
+    UnionSchema,
+};
 use apache_avro::Schema as AvroSchema;
+use serde_json::{Number, Value as JsonValue};
 use std::collections::BTreeMap;
+use std::iter::Iterator;
 
 impl<'a> TryFrom<&'a Schema> for AvroSchema {
     type Error = Error;
@@ -16,14 +21,10 @@ impl<'a> TryFrom<&'a Schema> for AvroSchema {
             .iter()
             .map(AvroRecordField::try_from)
             .collect::<Result<Vec<AvroRecordField>>>()?;
-        Ok(AvroSchema::Record(RecordSchema {
-            name: Name::from(format!("r_{}", value.schema_id).as_str()),
-            aliases: None,
-            doc: None,
-            fields: avro_fields,
-            lookup: BTreeMap::new(),
-            attributes: BTreeMap::new(),
-        }))
+        Ok(AvroSchema::Record(avro_record_schema(
+            format!("r_{}", value.schema_id).as_str(),
+            avro_fields,
+        )))
     }
 }
 
@@ -31,17 +32,31 @@ impl<'a> TryFrom<&'a Field> for AvroRecordField {
     type Error = Error;
 
     fn try_from(value: &'a Field) -> Result<AvroRecordField> {
-        let mut avro_schema = AvroSchema::try_from(&value.field_type)?;
-        // An ugly workaround, let's fix it later.
-        if let Any::Struct(_) = &value.field_type {
-            match &mut avro_schema {
-                AvroSchema::Record(r) => {
-                    r.name = Name::from(value.name.as_str());
-                    r.doc = value.comment.clone();
+        let avro_schema = match &value.field_type {
+            Any::Struct(_) => {
+                let mut avro_schema = AvroSchema::try_from(&value.field_type)?;
+                // An ugly workaround, let's fix it later.
+                if let Any::Struct(_) = &value.field_type {
+                    match &mut avro_schema {
+                        AvroSchema::Record(r) => {
+                            r.name = Name::from(value.name.as_str());
+                            r.doc = value.comment.clone();
+                        }
+                        _ => panic!("Struct record should be converted to avro struct schema."),
+                    }
                 }
-                _ => panic!("Struct record should be converted to avro struct schema."),
+                avro_schema
             }
-        }
+            _ => {
+                let mut avro_schema = AvroSchema::try_from(&value.field_type)?;
+                if !value.required {
+                    avro_schema =
+                        AvroSchema::Union(UnionSchema::new(vec![AvroSchema::Null, avro_schema])?);
+                }
+                avro_schema
+            }
+
+        };
 
         Ok(AvroRecordField {
             name: value.name.clone(),
@@ -84,20 +99,69 @@ impl<'a> TryFrom<&'a Any> for AvroSchema {
                     ))
                 }
             },
+
             Any::Map(map) => {
-                if *map.key_type != Any::Primitive(Primitive::String) {
-                    return Err(Error::new(
-                        ErrorKind::IcebergFeatureUnsupported,
-                        format!(
-                            "Unable to convert iceberg data type map with key type {:?} to avro type, since avro assumes keys are always strings",
-                            *map.key_type
-                        ),
-                    ));
+                if let Any::Primitive(Primitive::String) = *map.key_type {
+                    let mut value_avro_schema = AvroSchema::try_from(&*map.value_type)?;
+                    if !map.value_required {
+                        value_avro_schema = to_avro_option(value_avro_schema)?;
+                    }
+
+                    AvroSchema::Map(Box::new(value_avro_schema))
+                } else {
+                    let key_field = {
+                        let mut field = AvroRecordField {
+                            name: "key".to_string(),
+                            doc: None,
+                            aliases: None,
+                            default: None,
+                            schema: AvroSchema::try_from(&*map.key_type)?,
+                            order: RecordFieldOrder::Ignore,
+                            position: 0,
+                            custom_attributes: BTreeMap::default(),
+                        };
+                        field.custom_attributes.insert(
+                            "field-id".to_string(),
+                            JsonValue::Number(Number::from(map.key_id)),
+                        );
+                        field
+                    };
+
+                    let value_field = {
+                        let mut value_schema = AvroSchema::try_from(&*map.value_type)?;
+                        if !map.value_required {
+                            value_schema = to_avro_option(value_schema)?;
+                        }
+
+                        let mut field = AvroRecordField {
+                            name: "value".to_string(),
+                            doc: None,
+                            aliases: None,
+                            default: None,
+                            schema: value_schema,
+                            order: RecordFieldOrder::Ignore,
+                            position: 0,
+                            custom_attributes: BTreeMap::default(),
+                        };
+                        field.custom_attributes.insert(
+                            "field-id".to_string(),
+                            JsonValue::Number(Number::from(map.value_id)),
+                        );
+                        field
+                    };
+
+                    AvroSchema::Array(Box::new(AvroSchema::Record(avro_record_schema(
+                        format!("k{}_v{}", map.key_id, map.value_id).as_str(),
+                        vec![key_field, value_field],
+                    ))))
                 }
-                AvroSchema::Map(Box::new(AvroSchema::try_from(&*map.value_type)?))
             }
             Any::List(list) => {
-                AvroSchema::Array(Box::new(AvroSchema::try_from(&*list.element_type)?))
+                let mut avro_schema = AvroSchema::try_from(&*list.element_type)?;
+                if !list.element_required {
+                    avro_schema = to_avro_option(avro_schema)?;
+                }
+                AvroSchema::Array(Box::new(avro_schema))
             }
             Any::Struct(s) => {
                 let avro_fields: Vec<AvroRecordField> = s
@@ -105,18 +169,47 @@ impl<'a> TryFrom<&'a Any> for AvroSchema {
                     .iter()
                     .map(AvroRecordField::try_from)
                     .collect::<Result<Vec<AvroRecordField>>>()?;
-                AvroSchema::Record(RecordSchema {
-                    name: Name::from("invalid_name"),
-                    fields: avro_fields,
-                    aliases: None,
-                    doc: None,
-                    lookup: BTreeMap::new(),
-                    attributes: BTreeMap::new(),
-                })
+                AvroSchema::Record(avro_record_schema("invalid_name", avro_fields))
             }
         };
         Ok(avro_schema)
     }
+}
+
+fn avro_record_schema(
+    name: &str,
+    fields: impl IntoIterator<Item = AvroRecordField>,
+) -> AvroRecordSchema {
+    let avro_fields = fields.into_iter().collect::<Vec<AvroRecordField>>();
+    let lookup = avro_fields
+        .iter()
+        .enumerate()
+        .map(|f| (f.1.name.clone(), f.0))
+        .collect();
+
+    AvroRecordSchema {
+        name: Name::from(name),
+        fields: avro_fields,
+        aliases: None,
+        doc: None,
+        lookup,
+        attributes: BTreeMap::default(),
+    }
+}
+
+fn is_avro_option(avro_schema: &AvroSchema) -> bool {
+    match avro_schema {
+        AvroSchema::Union(u) => u.variants().len() == 2 && u.is_nullable(),
+        _ => false,
+    }
+}
+
+fn to_avro_option(avro_schema: AvroSchema) -> Result<AvroSchema> {
+    assert!(!is_avro_option(&avro_schema));
+    Ok(AvroSchema::Union(UnionSchema::new(vec![
+        AvroSchema::Null,
+        avro_schema,
+    ])?))
 }
 
 #[cfg(test)]
@@ -179,12 +272,12 @@ mod tests {
                             Field {
                                 id: 6,
                                 name: "f".to_string(),
-                                required: false,
+                                required: true,
                                 field_type: Any::Map(Map {
                                     key_id: 2,
                                     key_type: Box::new(Any::Primitive(Primitive::String)),
                                     value_id: 3,
-                                    value_required: false,
+                                    value_required: true,
                                     value_type: Box::new(Any::Primitive(Primitive::Binary)),
                                 }),
                                 comment: Some("comment_f".to_string()),


### PR DESCRIPTION
Closes #98 

Removed v1 manifest writer support in this pr. It may take some extra effort to be compatible with both v1 and v2, and currenlty we should focus on v2.  Let's add v1 writer later.