### PR TITLE
feat: replace f32,f64 with ordered_float

### DIFF
--- a/icelake/Cargo.toml
+++ b/icelake/Cargo.toml
@@ -27,6 +27,7 @@ rust_decimal ={workspace = true}
 chrono ={workspace = true}
 faster-hex ={workspace = true}
 once_cell = {workspace = true}
+ordered-float = "3.7.0"
 
 [dev-dependencies]
 tempfile = {workspace = true}

--- a/icelake/src/types/in_memory.rs
+++ b/icelake/src/types/in_memory.rs
@@ -8,6 +8,7 @@ use chrono::NaiveDateTime;
 use chrono::NaiveTime;
 use chrono::Utc;
 use opendal::Operator;
+use ordered_float::OrderedFloat;
 use rust_decimal::Decimal;
 use serde::ser::SerializeMap;
 use serde::ser::SerializeStruct;
@@ -149,9 +150,9 @@ pub enum PrimitiveValue {
     /// 64-bit signed integer
     Long(i64),
     /// 32-bit IEEE 753 floating bit, Can promote to double
-    Float(f32),
+    Float(OrderedFloat<f32>),
     /// 64-bit IEEE 753 floating bit.
-    Double(f64),
+    Double(OrderedFloat<f64>),
     /// Fixed point decimal
     Decimal(Decimal),
     /// Calendar date without timezone or time
@@ -197,8 +198,8 @@ impl Serialize for PrimitiveValue {
             PrimitiveValue::Boolean(value) => serializer.serialize_bool(*value),
             PrimitiveValue::Int(value) => serializer.serialize_i32(*value),
             PrimitiveValue::Long(value) => serializer.serialize_i64(*value),
-            PrimitiveValue::Float(value) => serializer.serialize_f32(*value),
-            PrimitiveValue::Double(value) => serializer.serialize_f64(*value),
+            PrimitiveValue::Float(value) => serializer.serialize_f32(value.0),
+            PrimitiveValue::Double(value) => serializer.serialize_f64(value.0),
             PrimitiveValue::Decimal(value) => serializer.serialize_str(&value.to_string()),
             PrimitiveValue::Date(value) => serializer.serialize_str(&value.to_string()),
             PrimitiveValue::Time(value) => serializer.serialize_str(&value.to_string()),

--- a/icelake/src/types/on_disk/types.rs
+++ b/icelake/src/types/on_disk/types.rs
@@ -476,7 +476,7 @@ fn parse_json_value_to_float(value: serde_json::Value) -> Result<types::AnyValue
                 }
 
                 Ok(types::AnyValue::Primitive(types::PrimitiveValue::Float(
-                    v as f32,
+                    (v as f32).into(),
                 )))
             } else {
                 Err(Error::new(
@@ -501,7 +501,9 @@ fn parse_json_value_to_double(value: serde_json::Value) -> Result<types::AnyValu
     match value {
         serde_json::Value::Number(v) => {
             if let Some(v) = v.as_f64() {
-                Ok(types::AnyValue::Primitive(types::PrimitiveValue::Double(v)))
+                Ok(types::AnyValue::Primitive(types::PrimitiveValue::Double(
+                    v.into(),
+                )))
             } else {
                 Err(Error::new(
                     ErrorKind::IcebergDataInvalid,


### PR DESCRIPTION
simple solution for #116. 

### Why I introduce ordred_float diretly

> The order: spec said we need to use -NaN < -Infinity < -value < -0 < 0 < value < Infinity < NaN.

I find that it's unapprpriate to implement this order in the custom float directly. If we implement -0 < 0 for the custom float, which means that `CustomFloat(-0) < CustomFloat(0)` will return true. Then what result of `CustomFloat(-0) == CustomFloat(0)` should return?:
1. true => it's confict with `CustomFloat(-0) < CustomFloat(0)`
2. flase => why -0 is unequal 0 

I think this order is specific for the iceberg partition order. So this order rule should implement as a custom order trait or implement for AnyValue. E.g.
```
// implement as a custom order trait
impl PartitionOrder for OrderedF32 {
    ...
}

```

> The hash: iceberg has hash specs for float value that: hashLong(doubleToLongBits(double(v))
>> Maybe we should do something extra here instead of store StructValue in hashmap directly.

I find that this hash is specific for the bucket transform. https://iceberg.apache.org/spec/#appendix-b-32-bit-hash-requirements:~:text=For%20hash%20function%20details%20by%20type%2C%20see%20Appendix%20B. So we also can implemment as specific hash trait rather than general hash trait. E.g.
```
impl BucketHash for OrderedF32 {
    // convert it to a 32bit hash
    fn hash() -> u32 {
        
    }
}
```

### What problem still in ordered_float

It can't support -nan. We have to custom a float in we want to support it. I'm not sure whether it's necessary to support it at this time. 