### PR TITLE
fix: return Vec<Datafile> instead of HashMap

### DIFF
--- a/icelake/src/io/task_writer.rs
+++ b/icelake/src/io/task_writer.rs
@@ -1,8 +1,6 @@
 //! task_writer module provide a task writer for writing data in a table.
 //! table writer used directly by the compute engine.
 
-use std::collections::HashMap;
-
 use arrow_array::RecordBatch;
 use arrow_schema::Schema as ArrowSchema;
 use opendal::Operator;
@@ -11,7 +9,7 @@ use super::data_file_writer::DataFileWriter;
 use super::location_generator;
 use crate::error::Result;
 use crate::io::location_generator::DataFileLocationGenerator;
-use crate::types::{DataFile, StructValue, TableMetadata};
+use crate::types::{DataFile, TableMetadata};
 
 /// `TaskWriter` used to write data for a table.
 ///
@@ -91,7 +89,7 @@ impl TaskWriter {
     }
 
     /// Close the writer and return the data files.
-    pub async fn close(self) -> Result<HashMap<StructValue, Vec<DataFile>>> {
+    pub async fn close(self) -> Result<Vec<DataFile>> {
         match self {
             Self::Unpartitioned(writer) => writer.close().await,
         }
@@ -137,10 +135,7 @@ impl UnpartitionedWriter {
     /// # Note
     ///
     /// For unpartitioned table, the key of the result map is default partition key.
-    pub async fn close(self) -> Result<HashMap<StructValue, Vec<DataFile>>> {
-        let datafiles = self.data_file_writer.close().await?;
-        let mut result = HashMap::new();
-        result.insert(StructValue::default(), datafiles);
-        Ok(result)
+    pub async fn close(self) -> Result<Vec<DataFile>> {
+        self.data_file_writer.close().await
     }
 }


### PR DESCRIPTION
I find that task writer don't need to return `HashMap<StructValue,DataFile>`. 

User will use it like following and it probably don't need to know the partition details.

```
let table = create_table();

let task_writer = table.task_writer();

// TaskWriter partition for user, they don't need to know the details.
task_writer.writer(records);

let res = task_writer.close();

let transaction = transaction::new(&mut table);

// Just pass the result to transaction.
transaction.append_datafile(res);

transaction.commit();
```