### PR TITLE
require `Send` for `TransformFunction`

### DIFF
--- a/icelake/src/types/transform/mod.rs
+++ b/icelake/src/types/transform/mod.rs
@@ -4,7 +4,7 @@ use arrow::array::ArrayRef;
 mod identity;
 
 /// TransformFunction is a trait that defines the interface of a transform function.
-pub trait TransformFunction {
+pub trait TransformFunction: Send {
     /// transform will take an input array and transform it into a new array.
     /// The implementation of this function will need to check and downcast the input to specific
     /// type.


### PR DESCRIPTION
RisingWave requires `icelake::io::task_writer::TaskWriter` can be sent. cc @ZENOTME 
https://github.com/risingwavelabs/risingwave/blob/6b6f7177ea58d1ce4aab0ade1985471bd1c525cc/src/connector/src/sink/iceberg.rs#L365