### PR TITLE
feat: Implement rest catalog tables and add test framework

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,5 @@ futures = { version = "0.3", features = ["executor"] }
 testcontainers = { git = "https://github.com/liurenjie1024/testcontainers-rs.git", rev = "24fd08c05aa72ca7542198056c8c592a1899fd39" }
 iceberg-rest-api = { path = "./rest_api" }
 murmur3 = "0.5.2"
+reqwest = "0.11"
+urlencoding = "2"

--- a/icelake/Cargo.toml
+++ b/icelake/Cargo.toml
@@ -41,6 +41,9 @@ toml = "0.7.6"
 csv = "1.2.2"
 iceberg-rest-api = { workspace = true }
 murmur3 = { workspace = true }
+reqwest = { workspace = true }
+urlencoding = { workspace = true }
+
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/icelake/src/catalog/rest.rs
+++ b/icelake/src/catalog/rest.rs
@@ -4,29 +4,61 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
+use iceberg_rest_api::{
+    apis::{
+        catalog_api_api::list_tables, configuration::Configuration,
+        configuration_api_api::get_config,
+    },
+    models::TableIdentifier as RestTableIdentifier,
+};
+use reqwest::ClientBuilder;
 
 use crate::{
     table::{Namespace, TableIdentifier},
     types::{PartitionSpec, Schema},
-    Table,
+    Error, ErrorKind, Table,
 };
 
 use super::{Catalog, UpdateTable};
 use crate::error::Result;
 
+/// Configuration for rest catalog.
+#[derive(Debug, Default)]
+pub struct RestCatalogConfig {
+    uri: String,
+    prefix: Option<String>,
+    warehouse: Option<String>,
+}
+
 /// Rest catalog implementation
-pub struct RestCatalog {}
+pub struct RestCatalog {
+    name: String,
+    config: RestCatalogConfig,
+    // rest client config
+    rest_client: Configuration,
+}
 
 #[async_trait]
 impl Catalog for RestCatalog {
     /// Return catalog's name.
     fn name(&self) -> &str {
-        todo!()
+        &self.name
     }
 
     /// List tables under namespace.
-    async fn list_tables(&self, _ns: &Namespace) -> Result<Vec<TableIdentifier>> {
-        todo!()
+    async fn list_tables(&self, ns: &Namespace) -> Result<Vec<TableIdentifier>> {
+        let resp = list_tables(
+            &self.rest_client,
+            self.config.prefix.as_deref(),
+            &ns.encode_in_url()?,
+        )
+        .await?;
+        Ok(resp
+            .identifiers
+            .unwrap_or_default()
+            .iter()
+            .map(TableIdentifier::from)
+            .collect())
     }
 
     /// Creates a table.
@@ -38,32 +70,50 @@ impl Catalog for RestCatalog {
         _location: &str,
         _props: HashMap<String, String>,
     ) -> Result<Table> {
-        todo!()
+        Err(Error::new(
+            ErrorKind::IcebergFeatureUnsupported,
+            "Creating table in rest client is not implemented yet!",
+        ))
     }
 
     /// Check table exists.
     async fn table_exists(&self, _table_name: &TableIdentifier) -> Result<bool> {
-        todo!()
+        Err(Error::new(
+            ErrorKind::IcebergFeatureUnsupported,
+            "Table exists in rest client is not implemented yet!",
+        ))
     }
 
     /// Drop table.
     async fn drop_table(&self, _table_name: &TableIdentifier, _purge: bool) -> Result<()> {
-        todo!()
+        Err(Error::new(
+            ErrorKind::IcebergFeatureUnsupported,
+            "Drop table in rest client is not implemented yet!",
+        ))
     }
 
     /// Rename table.
     async fn rename_table(&self, _from: &TableIdentifier, _to: &TableIdentifier) -> Result<()> {
-        todo!()
+        Err(Error::new(
+            ErrorKind::IcebergFeatureUnsupported,
+            "Rename table in rest client is not implemented yet!",
+        ))
     }
 
     /// Load table.
     async fn load_table(&self, _table_name: &TableIdentifier) -> Result<Table> {
-        todo!()
+        Err(Error::new(
+            ErrorKind::IcebergFeatureUnsupported,
+            "Load table in rest client is not implemented yet!",
+        ))
     }
 
     /// Invalidate table.
     async fn invalidate_table(&self, _table_name: &TableIdentifier) -> Result<()> {
-        todo!()
+        Err(Error::new(
+            ErrorKind::IcebergFeatureUnsupported,
+            "Invalidate table in rest client is not implemented yet!",
+        ))
     }
 
     /// Register a table using metadata file location.
@@ -72,11 +122,130 @@ impl Catalog for RestCatalog {
         _table_name: &TableIdentifier,
         _metadata_file_location: &str,
     ) -> Result<Table> {
-        todo!()
+        Err(Error::new(
+            ErrorKind::IcebergFeatureUnsupported,
+            "Register table in rest client is not implemented yet!",
+        ))
     }
 
     /// Update table.
     async fn update_table(&self, _udpate_table: &UpdateTable) -> Result<Table> {
-        todo!()
+        Err(Error::new(
+            ErrorKind::IcebergFeatureUnsupported,
+            "Update table in rest client is not implemented yet!",
+        ))
+    }
+}
+
+impl RestCatalog {
+    /// Creates rest catalog.
+    pub async fn new(name: impl AsRef<str>, config: HashMap<String, String>) -> Result<Self> {
+        let catalog_config = RestCatalog::init_config_from_server(config).await?;
+        let rest_client = RestCatalog::create_rest_client(&catalog_config)?;
+
+        Ok(Self {
+            name: name.as_ref().to_string(),
+            config: catalog_config,
+            rest_client,
+        })
+    }
+
+    fn create_rest_client(config: &RestCatalogConfig) -> Result<Configuration> {
+        let mut client = Configuration {
+            base_path: config.uri.to_string(),
+            ..Default::default()
+        };
+
+        let req = { ClientBuilder::new().build()? };
+
+        client.client = req;
+
+        Ok(client)
+    }
+
+    async fn init_config_from_server(config: HashMap<String, String>) -> Result<RestCatalogConfig> {
+        log::info!("Creating rest catalog with user config: {config:?}");
+        let rest_catalog_config = RestCatalogConfig::try_from(&config)?;
+        let rest_client = RestCatalog::create_rest_client(&rest_catalog_config)?;
+
+        let mut server_config =
+            get_config(&rest_client, rest_catalog_config.warehouse.as_deref()).await?;
+
+        log::info!("Catalog config from rest catalog server: {server_config:?}");
+        server_config.defaults.extend(config);
+        server_config.defaults.extend(server_config.overrides);
+
+        let ret = RestCatalogConfig::try_from(&server_config.defaults)?;
+
+        log::info!("Result rest catalog config after merging with catalog server config: {ret:?}");
+        Ok(ret)
+    }
+}
+
+impl TryFrom<&HashMap<String, String>> for RestCatalogConfig {
+    type Error = Error;
+
+    fn try_from(value: &HashMap<String, String>) -> Result<RestCatalogConfig> {
+        let mut config = RestCatalogConfig {
+            uri: value
+                .get("uri")
+                .ok_or_else(|| {
+                    Error::new(
+                        ErrorKind::IcebergDataInvalid,
+                        "uri is missing for rest catalog.",
+                    )
+                })?
+                .clone(),
+            ..Default::default()
+        };
+
+        if let Some(warehouse) = value.get("warehouse") {
+            config.warehouse = Some(warehouse.clone());
+        }
+
+        if let Some(prefix) = value.get("prefix") {
+            config.prefix = Some(prefix.clone());
+        }
+
+        Ok(config)
+    }
+}
+
+impl From<&RestTableIdentifier> for TableIdentifier {
+    fn from(value: &RestTableIdentifier) -> Self {
+        Self {
+            namespace: Namespace {
+                levels: value.namespace.clone(),
+            },
+            name: value.name.clone(),
+        }
+    }
+}
+
+impl Namespace {
+    /// Returns url encoded format.
+    pub fn encode_in_url(&self) -> Result<String> {
+        if self.levels.is_empty() {
+            return Err(Error::new(
+                ErrorKind::IcebergDataInvalid,
+                "Can't encode empty namespace in url!",
+            ));
+        }
+
+        Ok(self.levels.join("\u{1F}").to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::table::Namespace;
+
+    #[test]
+    fn test_namespace_encode() {
+        let ns = Namespace {
+            levels: vec!["a".to_string(), "b".to_string()],
+        };
+
+        assert_eq!("a\u{1F}b", ns.encode_in_url().unwrap());
     }
 }

--- a/icelake/src/error.rs
+++ b/icelake/src/error.rs
@@ -231,6 +231,22 @@ impl From<std::num::ParseIntError> for Error {
     }
 }
 
+impl From<reqwest::Error> for Error {
+    fn from(value: reqwest::Error) -> Self {
+        Self::new(ErrorKind::Unexpected, "Failed to create client").set_source(value)
+    }
+}
+
+impl<T: std::fmt::Debug + Send + Sync + 'static> From<iceberg_rest_api::apis::Error<T>> for Error {
+    fn from(value: iceberg_rest_api::apis::Error<T>) -> Self {
+        Self::new(
+            ErrorKind::Unexpected,
+            "Failed to request from catalog server",
+        )
+        .set_source(value)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use anyhow::anyhow;

--- a/icelake/src/lib.rs
+++ b/icelake/src/lib.rs
@@ -6,7 +6,7 @@
 #![allow(dead_code)]
 
 mod table;
-pub use table::Table;
+pub use table::*;
 mod error;
 pub use error::Error;
 pub use error::ErrorKind;

--- a/icelake/tests/insert_tests.rs
+++ b/icelake/tests/insert_tests.rs
@@ -1,7 +1,7 @@
-use crate::utils::{mc_image, minio_image, set_up, spark_image, Poetry, TestFixture};
 use testcontainers::clients::Cli;
 
 mod utils;
+pub use utils::*;
 
 fn create_test_fixture<'a>(cli: &'a Cli, toml_file: &str) -> TestFixture<'a> {
     set_up();

--- a/icelake/tests/rest_catalog_tests.rs
+++ b/icelake/tests/rest_catalog_tests.rs
@@ -1,0 +1,93 @@
+use std::collections::HashMap;
+
+use icelake::{
+    catalog::{Catalog, RestCatalog},
+    Namespace, TableIdentifier,
+};
+
+use utils::{DockerCompose, Poetry};
+
+use crate::utils::set_up;
+
+mod utils;
+use utils::REST_CATALOG_PORT;
+use utils::SPARK_CONNECT_SERVER_PORT;
+
+struct TestFixture {
+    docker_compose: DockerCompose,
+    poetry: Poetry,
+}
+
+fn create_test_fixture(project_name: &str) -> TestFixture {
+    set_up();
+
+    let docker_compose = DockerCompose::new(project_name, "iceberg-rest");
+    let poetry = Poetry::new(format!("{}/../testdata/python", env!("CARGO_MANIFEST_DIR")));
+
+    TestFixture {
+        docker_compose,
+        poetry,
+    }
+}
+
+#[tokio::test]
+async fn test_list_tables() {
+    let test_fixture = create_test_fixture("test2");
+
+    test_fixture.docker_compose.run();
+
+    test_fixture.poetry.run_file(
+        "init.py",
+        vec![
+            "-s",
+            &format!(
+                "sc://{}:{}",
+                test_fixture.docker_compose.get_container_ip("spark"),
+                SPARK_CONNECT_SERVER_PORT
+            ),
+            "--sql",
+            "CREATE SCHEMA IF NOT EXISTS s1",
+            "DROP TABLE IF EXISTS s1.t1",
+            "CREATE TABLE s1.t1 (id long) using ICEBERG TBLPROPERTIES ('format-version'='2')",
+            "DROP TABLE IF EXISTS s1.t2",
+            "CREATE TABLE s1.t2 (id long) using ICEBERG TBLPROPERTIES ('format-version'='2')",
+            "CREATE SCHEMA IF NOT EXISTS s2",
+            "DROP TABLE IF EXISTS s2.t1",
+            "CREATE TABLE s2.t1 (id long) using ICEBERG TBLPROPERTIES ('format-version'='2')",
+        ],
+        "Init spark tables",
+    );
+
+    let config: HashMap<String, String> = HashMap::from([(
+        "uri",
+        format!(
+            "http://{}:{REST_CATALOG_PORT}",
+            test_fixture.docker_compose.get_container_ip("rest")
+        ),
+    )])
+    .iter()
+    .map(|(k, v)| (k.to_string(), v.to_string()))
+    .collect();
+
+    let catalog = RestCatalog::new("test", config).await.unwrap();
+
+    let mut table_ids = catalog
+        .list_tables(&Namespace::new(vec!["s1"]))
+        .await
+        .unwrap();
+
+    let s2_table_ids = catalog
+        .list_tables(&Namespace::new(vec!["s2"]))
+        .await
+        .unwrap();
+
+    table_ids.extend(s2_table_ids);
+
+    let expected_tables = vec![
+        TableIdentifier::new(vec!["s1", "t1"]).unwrap(),
+        TableIdentifier::new(vec!["s1", "t2"]).unwrap(),
+        TableIdentifier::new(vec!["s2", "t1"]).unwrap(),
+    ];
+
+    assert_eq!(expected_tables, table_ids);
+}

--- a/icelake/tests/rest_catalog_tests.rs
+++ b/icelake/tests/rest_catalog_tests.rs
@@ -5,26 +5,21 @@ use icelake::{
     Namespace, TableIdentifier,
 };
 
-use utils::{DockerCompose, Poetry};
-
-use crate::utils::set_up;
-
 mod utils;
-use utils::REST_CATALOG_PORT;
-use utils::SPARK_CONNECT_SERVER_PORT;
+pub use utils::*;
 
-struct TestFixture {
+struct TestFixture2 {
     docker_compose: DockerCompose,
     poetry: Poetry,
 }
 
-fn create_test_fixture(project_name: &str) -> TestFixture {
+fn create_test_fixture(project_name: &str) -> TestFixture2 {
     set_up();
 
     let docker_compose = DockerCompose::new(project_name, "iceberg-rest");
     let poetry = Poetry::new(format!("{}/../testdata/python", env!("CARGO_MANIFEST_DIR")));
 
-    TestFixture {
+    TestFixture2 {
         docker_compose,
         poetry,
     }

--- a/icelake/tests/utils/containers.rs
+++ b/icelake/tests/utils/containers.rs
@@ -10,11 +10,6 @@ pub const MINIO_SECRET_KEY: &str = "password";
 
 pub const SPARK_CONNECT_SERVER_PORT: u16 = 15002u16;
 
-pub const PG_DB: &str = "postgres";
-pub const PG_USERNAME: &str = "postgres";
-pub const PG_PASSWORD: &str = "123456";
-pub const PG_PORT: u16 = 5432;
-
 pub const REST_CATALOG_WAREHOUSE: &str = "s3://icebergdata/demo";
 pub const REST_CATALOG_PORT: u16 = 8181;
 

--- a/icelake/tests/utils/containers.rs
+++ b/icelake/tests/utils/containers.rs
@@ -5,8 +5,18 @@ use testcontainers::{GenericImage, RunnableImage};
 
 pub const MINIO_DATA_PORT: u16 = 9000u16;
 pub const MINIO_CONSOLE_PORT: u16 = 9001u16;
+pub const MINIO_ACCESS_KEY: &str = "admin";
+pub const MINIO_SECRET_KEY: &str = "password";
 
 pub const SPARK_CONNECT_SERVER_PORT: u16 = 15002u16;
+
+pub const PG_DB: &str = "postgres";
+pub const PG_USERNAME: &str = "postgres";
+pub const PG_PASSWORD: &str = "123456";
+pub const PG_PORT: u16 = 5432;
+
+pub const REST_CATALOG_WAREHOUSE: &str = "s3://icebergdata/demo";
+pub const REST_CATALOG_PORT: u16 = 8181;
 
 pub fn spark_image(minio_ip: &IpAddr) -> RunnableImage<GenericImage> {
     RunnableImage::from(
@@ -22,8 +32,8 @@ pub fn spark_image(minio_ip: &IpAddr) -> RunnableImage<GenericImage> {
         .with_exposed_port(SPARK_CONNECT_SERVER_PORT)
         .with_entrypoint("/spark-script/spark-connect-server.sh")
         .with_wait_for(WaitFor::StdOutMessage { message: "SparkConnectServer: Spark Connect server started".to_string()})
-        .with_wait_for(WaitFor::Duration { length: Duration::from_secs(5)}))
-        .with_user("root")
+        .with_wait_for(WaitFor::Duration { length: Duration::from_secs(2)}))
+    .with_user("root")
 }
 
 pub fn minio_image() -> RunnableImage<GenericImage> {

--- a/icelake/tests/utils/docker.rs
+++ b/icelake/tests/utils/docker.rs
@@ -1,0 +1,88 @@
+use std::process::Command;
+
+use super::{get_cmd_output, run_command};
+
+pub struct DockerCompose {
+    project_name: String,
+    docker_compose_dir: String,
+}
+
+impl DockerCompose {
+    pub fn new(project_name: impl ToString, docker_compose_dir: impl ToString) -> Self {
+        Self {
+            project_name: project_name.to_string(),
+            docker_compose_dir: docker_compose_dir.to_string(),
+        }
+    }
+
+    pub fn run(&self) {
+        let mut cmd = Command::new("docker");
+        let absolute_dir = format!(
+            "{}/../testdata/docker/{}",
+            env!("CARGO_MANIFEST_DIR"),
+            self.docker_compose_dir
+        );
+        cmd.current_dir(absolute_dir.as_str());
+
+        cmd.args(vec![
+            "compose",
+            "-p",
+            self.project_name.as_str(),
+            "up",
+            "-d",
+            "--wait",
+            "--timeout",
+            "1200000",
+        ]);
+
+        run_command(
+            cmd,
+            format!(
+                "Starting docker compose in {absolute_dir}, project name: {}",
+                self.project_name
+            ),
+        )
+    }
+
+    pub fn get_container_ip(&self, service_name: impl AsRef<str>) -> String {
+        let container_name = format!("{}-{}-1", self.project_name, service_name.as_ref());
+        let mut cmd = Command::new("docker");
+        cmd.arg("inspect")
+            .arg("-f")
+            .arg("{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}")
+            .arg(&container_name);
+
+        get_cmd_output(cmd, format!("Get container ip of {container_name}"))
+            .trim()
+            .to_string()
+    }
+}
+
+impl Drop for DockerCompose {
+    fn drop(&mut self) {
+        let mut cmd = Command::new("docker");
+        let absolute_dir = format!(
+            "{}/../testdata/docker/{}",
+            env!("CARGO_MANIFEST_DIR"),
+            self.docker_compose_dir
+        );
+        cmd.current_dir(absolute_dir.as_str());
+
+        cmd.args(vec![
+            "compose",
+            "-p",
+            self.project_name.as_str(),
+            "down",
+            "-v",
+            "--remove-orphans",
+        ]);
+
+        run_command(
+            cmd,
+            format!(
+                "Stopping docker compose in {absolute_dir}, project name: {}",
+                self.project_name
+            ),
+        )
+    }
+}

--- a/icelake/tests/utils/mod.rs
+++ b/icelake/tests/utils/mod.rs
@@ -5,9 +5,11 @@ mod poetry;
 pub use poetry::*;
 
 mod containers;
+mod docker;
 mod test_generator;
 
 pub use containers::*;
+pub use docker::*;
 
 use icelake::transaction::Transaction;
 use icelake::Table;
@@ -34,6 +36,18 @@ pub fn run_command(mut cmd: Command, desc: impl ToString) {
         log::info!("{} succeed!", desc)
     } else {
         panic!("{} failed: {:?}", desc, exit);
+    }
+}
+
+pub fn get_cmd_output(mut cmd: Command, desc: impl ToString) -> String {
+    let desc = desc.to_string();
+    log::info!("Starting to {}, command: {:?}", &desc, cmd);
+    let output = cmd.output().unwrap();
+    if output.status.success() {
+        log::info!("{} succeed!", desc);
+        String::from_utf8(output.stdout).unwrap()
+    } else {
+        panic!("{} failed: {:?}", desc, output.status);
     }
 }
 

--- a/rest_api/src/apis/catalog_api_api.rs
+++ b/rest_api/src/apis/catalog_api_api.rs
@@ -468,19 +468,32 @@ pub async fn list_namespaces(
 /// Return all table identifiers under this namespace
 pub async fn list_tables(
     configuration: &configuration::Configuration,
-    prefix: &str,
+    prefix: Option<&str>,
     namespace: &str,
 ) -> Result<crate::models::ListTablesResponse, Error<ListTablesError>> {
     let local_var_configuration = configuration;
 
     let local_var_client = &local_var_configuration.client;
 
-    let local_var_uri_str = format!(
-        "{}/v1/{prefix}/namespaces/{namespace}/tables",
-        local_var_configuration.base_path,
-        prefix = crate::apis::urlencode(prefix),
-        namespace = crate::apis::urlencode(namespace)
-    );
+    let local_var_uri_str = match prefix {
+        Some(p) => {
+            format!(
+                "{}/v1/{prefix}/namespaces/{namespace}/tables",
+                local_var_configuration.base_path,
+                prefix = crate::apis::urlencode(p),
+                namespace = crate::apis::urlencode(namespace)
+            )
+        }
+        None => {
+            format!(
+                "{}/v1/namespaces/{namespace}/tables",
+                local_var_configuration.base_path,
+                namespace = crate::apis::urlencode(namespace)
+            )
+        }
+    };
+
+    println!("{local_var_uri_str}");
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());
 

--- a/testdata/docker/iceberg-rest/docker-compose.yaml
+++ b/testdata/docker/iceberg-rest/docker-compose.yaml
@@ -1,0 +1,68 @@
+version: '3.8'
+
+services:
+  rest:
+    image: tabulario/iceberg-rest:0.6.0
+    environment:
+      - CATALOG_CATOLOG__IMPL=org.apache.iceberg.jdbc.JdbcCatalog
+      - CATALOG_URI=jdbc:sqlite:file:/tmp/iceberg_rest_mode=memory
+      - CATALOG_WAREHOUSE=s3://icebergdata/demo
+      - CATALOG_IO__IMPL=org.apache.iceberg.aws.s3.S3FileIO
+      - CATALOG_S3_ENDPOINT=http://minio:9000
+      - AWS_ACCESS_KEY_ID=admin
+      - AWS_SECRET_ACCESS_KEY=password
+      - AWS_REGION=us-east-1
+    depends_on:
+      - minio
+    links:
+      - minio:icebergdata.minio
+    expose:
+      - 8181
+
+  minio:
+    image: minio/minio
+    environment:
+      - MINIO_ROOT_USER=admin
+      - MINIO_ROOT_PASSWORD=password
+      - MINIO_DOMAIN=minio
+    expose:
+      - 9001
+      - 9000
+    command: ["server", "/data", "--console-address", ":9001"]
+
+  mc:
+    depends_on:
+      - minio
+    image: minio/mc
+    environment:
+      - AWS_ACCESS_KEY_ID=admin
+      - AWS_SECRET_ACCESS_KEY=password
+      - AWS_REGION=us-east-1
+    entrypoint: >
+      /bin/sh -c "
+      until (/usr/bin/mc config host add minio http://minio:9000 admin password) do echo '...waiting...' && sleep 1; done;
+      /usr/bin/mc rm -r --force minio/icebergdata;
+      /usr/bin/mc mb minio/icebergdata;
+      /usr/bin/mc policy set public minio/icebergdata;
+      tail -f /dev/null
+      "      
+  
+  spark:
+    depends_on:
+      - minio
+      - rest
+    image: apache/spark:3.4.1
+    environment:
+      - SPARK_HOME=/opt/spark
+      - PYSPARK_PYTON=/usr/bin/python3.9
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/spark/bin:/opt/spark/sbin
+    user: root
+    expose:
+      - 15002
+    healthcheck:
+      test: netstat -ltn | grep -c 15002
+      interval: 1s
+      retries: 1200
+    volumes:
+      - ../spark-script:/spark-script
+    entrypoint: ["/spark-script/spark-connect-server2.sh"]

--- a/testdata/docker/spark-script/spark-connect-server2.sh
+++ b/testdata/docker/spark-script/spark-connect-server2.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -ex
+
+# HTTP_PROXY=socks5://192.168.110.27:7890
+# HTTPS_PROXY=socks5://192.168.110.27:7890
+#  --conf spark.driver.extraJavaOptions="-Dhttps.proxyHost=192.168.110.27 -Dhttps.proxyPort=7890" \
+
+ICEBERG_VERSION=1.3.1
+SPARK_VERSION=3.4.1
+
+PACKAGES="org.apache.iceberg:iceberg-spark-runtime-3.4_2.12:$ICEBERG_VERSION"
+PACKAGES="$PACKAGES,org.apache.spark:spark-connect_2.12:$SPARK_VERSION"
+
+# add AWS dependency
+AWS_SDK_VERSION=2.20.18
+AWS_MAVEN_GROUP=software.amazon.awssdk
+AWS_PACKAGES=(
+    "bundle"
+)
+for pkg in "${AWS_PACKAGES[@]}"; do
+    PACKAGES+=",$AWS_MAVEN_GROUP:$pkg:$AWS_SDK_VERSION"
+done
+
+echo "$PACKAGES"
+
+/opt/spark/sbin/start-connect-server.sh --packages $PACKAGES \
+  --master local[3] \
+  --conf spark.driver.bindAddress=0.0.0.0 \
+  --conf spark.sql.catalog.demo=org.apache.iceberg.spark.SparkCatalog \
+  --conf spark.sql.catalog.demo.catalog-impl=org.apache.iceberg.rest.RESTCatalog \
+  --conf spark.sql.catalog.demo.io-impl=org.apache.iceberg.aws.s3.S3FileIO \
+  --conf spark.sql.catalog.demo.uri=http://rest:8181 \
+  --conf spark.sql.defaultCatalog=demo
+
+tail -f /opt/spark/logs/spark*.out


### PR DESCRIPTION
Close #175 

1. Implement list tables api.
2. Use docker compose rather testcontainers to setup test. I realized that in fact we can run docker compose in parallel and avoid confliction.
3. Setup test framework.