### PR TITLE
chore: prepare version 0.0.10.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.0.9"
+version = "0.0.10"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
The crates dependencies are changed frequently recently (especially arrow). It's better to release a new version.