### PR TITLE
feat: support position delete writer

### DIFF
--- a/icelake/src/catalog/rest.rs
+++ b/icelake/src/catalog/rest.rs
@@ -288,8 +288,7 @@ impl Endpoint {
             &ns.encode_in_url()?,
             "tables",
         ]
-        .join("/")
-        .to_string())
+        .join("/"))
     }
 
     fn table(&self, table: &TableIdentifier) -> Result<String> {
@@ -301,8 +300,7 @@ impl Endpoint {
             "tables",
             encode(&table.name).as_ref(),
         ]
-        .join("/")
-        .to_string())
+        .join("/"))
     }
 }
 

--- a/icelake/src/catalog/storage.rs
+++ b/icelake/src/catalog/storage.rs
@@ -352,18 +352,12 @@ impl StorageCatalog {
 
 impl Namespace {
     fn to_path(&self) -> Result<String> {
-        Ok(self.levels.iter().join("/").to_string())
+        Ok(self.levels.iter().join("/"))
     }
 }
 
 impl TableIdentifier {
     fn to_path(&self) -> Result<String> {
-        Ok(self
-            .namespace
-            .levels
-            .iter()
-            .chain([&self.name])
-            .join("/")
-            .to_string())
+        Ok(self.namespace.levels.iter().chain([&self.name]).join("/"))
     }
 }

--- a/icelake/src/io/data_file_writer.rs
+++ b/icelake/src/io/data_file_writer.rs
@@ -1,15 +1,12 @@
 //! A module provide `DataFileWriter`.
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 use crate::config::TableConfigRef;
-use crate::{
-    types::{DataFile, StructValue},
-    Result,
-};
+use crate::types::DataFileBuilder;
+use crate::Result;
 use arrow_array::RecordBatch;
 use arrow_schema::SchemaRef;
 use opendal::Operator;
-use parquet::format::FileMetaData;
 
 use super::location_generator::DataFileLocationGenerator;
 use super::rolling_writer::RollingWriter;
@@ -52,107 +49,18 @@ impl DataFileWriter {
     }
 
     /// Complte the write and return the list of `DataFile` as result.
-    pub async fn close(self) -> Result<Vec<DataFile>> {
-        let table_location = self.table_location;
+    pub async fn close(self) -> Result<Vec<DataFileBuilder>> {
         Ok(self
             .inner_writer
             .close()
             .await?
             .into_iter()
-            .map(|meta| {
-                Self::convert_meta_to_datafile(
-                    meta.meta_data,
-                    meta.written_size,
-                    &table_location,
-                    &meta.location,
-                )
+            .map(|builder| {
+                builder
+                    .with_content(crate::types::DataContentType::Data)
+                    .with_table_location(self.table_location.clone())
             })
             .collect())
-    }
-
-    fn convert_meta_to_datafile(
-        meta_data: FileMetaData,
-        written_size: u64,
-        table_location: &str,
-        current_location: &str,
-    ) -> DataFile {
-        log::info!("{meta_data:?}");
-        let (column_sizes, value_counts, null_value_counts, distinct_counts) = {
-            // how to decide column id
-            let mut per_col_size: HashMap<i32, _> = HashMap::new();
-            let mut per_col_val_num: HashMap<i32, _> = HashMap::new();
-            let mut per_col_null_val_num: HashMap<i32, _> = HashMap::new();
-            let mut per_col_distinct_val_num: HashMap<i32, _> = HashMap::new();
-            meta_data.row_groups.iter().for_each(|group| {
-                group
-                    .columns
-                    .iter()
-                    .enumerate()
-                    .for_each(|(column_id, column_chunk)| {
-                        if let Some(column_chunk_metadata) = &column_chunk.meta_data {
-                            *per_col_size.entry(column_id as i32).or_insert(0) +=
-                                column_chunk_metadata.total_compressed_size;
-                            *per_col_val_num.entry(column_id as i32).or_insert(0) +=
-                                column_chunk_metadata.num_values;
-                            *per_col_null_val_num
-                                .entry(column_id as i32)
-                                .or_insert(0_i64) += column_chunk_metadata
-                                .statistics
-                                .as_ref()
-                                .map(|s| s.null_count)
-                                .unwrap_or(None)
-                                .unwrap_or(0);
-                            *per_col_distinct_val_num
-                                .entry(column_id as i32)
-                                .or_insert(0_i64) += column_chunk_metadata
-                                .statistics
-                                .as_ref()
-                                .map(|s| s.distinct_count)
-                                .unwrap_or(None)
-                                .unwrap_or(0);
-                        }
-                    })
-            });
-            (
-                per_col_size,
-                per_col_val_num,
-                per_col_null_val_num,
-                per_col_distinct_val_num,
-            )
-        };
-        DataFile {
-            content: crate::types::DataContentType::Data,
-            file_path: format!("{}/{}", table_location, current_location),
-            file_format: crate::types::DataFileFormat::Parquet,
-            // /// # NOTE
-            // ///
-            // /// DataFileWriter only response to write data. Partition should place by more high level writer.
-            partition: StructValue::default(),
-            record_count: meta_data.num_rows,
-            column_sizes: Some(column_sizes),
-            value_counts: Some(value_counts),
-            null_value_counts: Some(null_value_counts),
-            distinct_counts: Some(distinct_counts),
-            key_metadata: meta_data.footer_signing_key_metadata,
-            file_size_in_bytes: written_size as i64,
-            /// # TODO
-            ///
-            /// Following fields unsupported now:
-            /// - `file_size_in_bytes` can't get from `FileMetaData` now.
-            /// - `file_offset` in `FileMetaData` always be None now.
-            /// - `nan_value_counts` can't get from `FileMetaData` now.
-            // Currently arrow parquet writer doesn't fill row group offsets, we can use first column chunk offset for it.
-            split_offsets: Some(meta_data
-                .row_groups
-                .iter()
-                .filter_map(|group| group.file_offset)
-                .collect()),
-            nan_value_counts: None,
-            lower_bounds: None,
-            upper_bounds: None,
-            equality_ids: None,
-            sort_order_id: None,
-        }
     }
 }
 
@@ -212,7 +120,12 @@ mod test {
         writer.write(to_write.clone()).await?;
         writer.write(to_write.clone()).await?;
         writer.write(to_write.clone()).await?;
-        let data_files = writer.close().await?;
+        let data_files = writer
+            .close()
+            .await?
+            .into_iter()
+            .map(|f| f.build())
+            .collect::<Vec<_>>();
 
         let mut row_num = 0;
         for data_file in data_files {

--- a/icelake/src/io/data_file_writer.rs
+++ b/icelake/src/io/data_file_writer.rs
@@ -1,5 +1,4 @@
-//! This module is used create a data file writer to write data into files.
-
+//! A module provide `DataFileWriter`.
 use std::{collections::HashMap, sync::Arc};
 
 use crate::config::TableConfigRef;

--- a/icelake/src/io/mod.rs
+++ b/icelake/src/io/mod.rs
@@ -4,4 +4,6 @@
 pub mod data_file_writer;
 pub mod location_generator;
 pub mod parquet;
+pub mod position_delete_writer;
+pub mod rolling_writer;
 pub mod task_writer;

--- a/icelake/src/io/position_delete_writer.rs
+++ b/icelake/src/io/position_delete_writer.rs
@@ -1,4 +1,4 @@
-//! This module is used to create writer to write position delete data into files.
+//! A module provide `PositionDeleteWriter`.
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/icelake/src/io/position_delete_writer.rs
+++ b/icelake/src/io/position_delete_writer.rs
@@ -1,14 +1,12 @@
 //! A module provide `PositionDeleteWriter`.
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::config::TableConfigRef;
-use crate::types::{Any, DataFile, Field, Primitive, Schema, StructValue};
+use crate::types::{Any, DataFileBuilder, Field, Primitive, Schema};
 use crate::{types::Struct, Result};
 use arrow_array::RecordBatch;
 use opendal::Operator;
-use parquet::format::FileMetaData;
 
 use super::{location_generator::DataFileLocationGenerator, rolling_writer::RollingWriter};
 
@@ -76,106 +74,17 @@ impl PositionDeleteWriter {
     }
 
     /// Complte the write and return the list of `DataFile` as result.
-    pub async fn close(self) -> Result<Vec<DataFile>> {
-        let table_location = self.table_location;
+    pub async fn close(self) -> Result<Vec<DataFileBuilder>> {
         Ok(self
             .inner_writer
             .close()
             .await?
             .into_iter()
-            .map(|meta| {
-                Self::convert_meta_to_datafile(
-                    meta.meta_data,
-                    meta.written_size,
-                    &table_location,
-                    &meta.location,
-                )
+            .map(|builder| {
+                builder
+                    .with_content(crate::types::DataContentType::PostionDeletes)
+                    .with_table_location(self.table_location.clone())
             })
             .collect())
-    }
-
-    fn convert_meta_to_datafile(
-        meta_data: FileMetaData,
-        written_size: u64,
-        table_location: &str,
-        current_location: &str,
-    ) -> DataFile {
-        log::info!("{meta_data:?}");
-        let (column_sizes, value_counts, null_value_counts, distinct_counts) = {
-            // how to decide column id
-            let mut per_col_size: HashMap<i32, _> = HashMap::new();
-            let mut per_col_val_num: HashMap<i32, _> = HashMap::new();
-            let mut per_col_null_val_num: HashMap<i32, _> = HashMap::new();
-            let mut per_col_distinct_val_num: HashMap<i32, _> = HashMap::new();
-            meta_data.row_groups.iter().for_each(|group| {
-                group
-                    .columns
-                    .iter()
-                    .enumerate()
-                    .for_each(|(column_id, column_chunk)| {
-                        if let Some(column_chunk_metadata) = &column_chunk.meta_data {
-                            *per_col_size.entry(column_id as i32).or_insert(0) +=
-                                column_chunk_metadata.total_compressed_size;
-                            *per_col_val_num.entry(column_id as i32).or_insert(0) +=
-                                column_chunk_metadata.num_values;
-                            *per_col_null_val_num
-                                .entry(column_id as i32)
-                                .or_insert(0_i64) += column_chunk_metadata
-                                .statistics
-                                .as_ref()
-                                .map(|s| s.null_count)
-                                .unwrap_or(None)
-                                .unwrap_or(0);
-                            *per_col_distinct_val_num
-                                .entry(column_id as i32)
-                                .or_insert(0_i64) += column_chunk_metadata
-                                .statistics
-                                .as_ref()
-                                .map(|s| s.distinct_count)
-                                .unwrap_or(None)
-                                .unwrap_or(0);
-                        }
-                    })
-            });
-            (
-                per_col_size,
-                per_col_val_num,
-                per_col_null_val_num,
-                per_col_distinct_val_num,
-            )
-        };
-        DataFile {
-            content: crate::types::DataContentType::PostionDeletes,
-            file_path: format!("{}/{}", table_location, current_location),
-            file_format: crate::types::DataFileFormat::Parquet,
-            // /// # NOTE
-            // ///
-            // /// DataFileWriter only response to write data. Partition should place by more high level writer.
-            partition: StructValue::default(),
-            record_count: meta_data.num_rows,
-            column_sizes: Some(column_sizes),
-            value_counts: Some(value_counts),
-            null_value_counts: Some(null_value_counts),
-            distinct_counts: Some(distinct_counts),
-            key_metadata: meta_data.footer_signing_key_metadata,
-            file_size_in_bytes: written_size as i64,
-            /// # TODO
-            ///
-            /// Following fields unsupported now:
-            /// - `file_size_in_bytes` can't get from `FileMetaData` now.
-            /// - `file_offset` in `FileMetaData` always be None now.
-            /// - `nan_value_counts` can't get from `FileMetaData` now.
-            // Currently arrow parquet writer doesn't fill row group offsets, we can use first column chunk offset for it.
-            split_offsets: Some(meta_data
-                .row_groups
-                .iter()
-                .filter_map(|group| group.file_offset)
-                .collect()),
-            nan_value_counts: None,
-            lower_bounds: None,
-            upper_bounds: None,
-            equality_ids: None,
-            sort_order_id: None,
-        }
     }
 }

--- a/icelake/src/io/rolling_writer.rs
+++ b/icelake/src/io/rolling_writer.rs
@@ -1,0 +1,137 @@
+//! A writer capable of splitting incoming data into multiple files within one spec/partition based on the target file size.
+//! Thit writer is used by data_file writer or delete writer. It should not be used directly.
+use arrow_array::RecordBatch;
+use parquet::file::properties::{WriterProperties, WriterVersion};
+use std::sync::Arc;
+
+use crate::{config::TableConfigRef, io::parquet::ParquetWriterBuilder};
+use arrow_schema::SchemaRef;
+use opendal::Operator;
+
+use super::location_generator::DataFileLocationGenerator;
+use super::parquet::ParquetWriter;
+use crate::Result;
+
+pub(crate) struct FileMetaData {
+    pub(crate) meta_data: parquet::format::FileMetaData,
+    pub(crate) written_size: u64,
+    pub(crate) location: String,
+}
+
+/// A writer capable of splitting incoming data into multiple files within one spec/partition based on the target file size.
+/// When complete, it will return a list of `FileMetaData`.
+pub(crate) struct RollingWriter {
+    operator: Operator,
+    location_generator: Arc<DataFileLocationGenerator>,
+    arrow_schema: SchemaRef,
+
+    current_writer: Option<ParquetWriter>,
+    current_row_num: usize,
+    /// `current_location` used to clean up the file when no row is written to it.
+    current_location: String,
+
+    result: Vec<FileMetaData>,
+
+    table_config: TableConfigRef,
+}
+
+impl RollingWriter {
+    /// Create a new `DataFileWriter`.
+    pub async fn try_new(
+        operator: Operator,
+        location_generator: Arc<DataFileLocationGenerator>,
+        arrow_schema: SchemaRef,
+        table_config: TableConfigRef,
+    ) -> Result<Self> {
+        let mut writer = Self {
+            operator,
+            location_generator,
+            arrow_schema,
+            current_writer: None,
+            current_row_num: 0,
+            current_location: String::new(),
+            result: vec![],
+            table_config,
+        };
+        writer.open_new_writer().await?;
+        Ok(writer)
+    }
+
+    /// Write a record batch. The `DataFileWriter` will create a new file when the current row num is greater than `target_file_row_num`.
+    pub async fn write(&mut self, batch: RecordBatch) -> Result<()> {
+        self.current_writer
+            .as_mut()
+            .expect("Should not be none here")
+            .write(&batch)
+            .await?;
+        self.current_row_num += batch.num_rows();
+
+        if self.should_split() {
+            self.close_current_writer().await?;
+            self.open_new_writer().await?;
+        }
+        Ok(())
+    }
+
+    /// Complte the write and return the list of `DataFile` as result.
+    pub async fn close(mut self) -> Result<Vec<FileMetaData>> {
+        self.close_current_writer().await?;
+        Ok(self.result)
+    }
+
+    fn should_split(&self) -> bool {
+        self.current_row_num % self.table_config.datafile_writer.rows_per_file == 0
+            && self.current_writer.as_ref().unwrap().get_written_size()
+                >= self.table_config.datafile_writer.target_file_size_in_bytes
+    }
+
+    async fn close_current_writer(&mut self) -> Result<()> {
+        let current_writer = self.current_writer.take().expect("Should not be none here");
+        let (meta_data, written_size) = current_writer.close().await?;
+
+        // Check if this file is empty
+        if meta_data.num_rows == 0 {
+            self.operator
+                .delete(&self.current_location)
+                .await
+                .expect("Delete file failed");
+            return Ok(());
+        }
+
+        self.result.push(FileMetaData {
+            meta_data,
+            written_size,
+            location: self.current_location.clone(),
+        });
+        Ok(())
+    }
+
+    async fn open_new_writer(&mut self) -> Result<()> {
+        // open new write must call when current writer is closed or inited.
+        assert!(self.current_writer.is_none());
+
+        let location = self.location_generator.generate_name();
+        let file_writer = self.operator.writer(&location).await?;
+        let current_writer = {
+            let mut props = WriterProperties::builder()
+                .set_writer_version(WriterVersion::PARQUET_1_0)
+                .set_bloom_filter_enabled(self.table_config.parquet_writer.enable_bloom_filter)
+                .set_compression(self.table_config.parquet_writer.compression)
+                .set_max_row_group_size(self.table_config.parquet_writer.max_row_group_size)
+                .set_write_batch_size(self.table_config.parquet_writer.write_batch_size)
+                .set_data_page_size_limit(self.table_config.parquet_writer.data_page_size);
+
+            if let Some(created_by) = self.table_config.parquet_writer.created_by.as_ref() {
+                props = props.set_created_by(created_by.to_string());
+            }
+
+            ParquetWriterBuilder::new(file_writer, self.arrow_schema.clone())
+                .with_properties(props.build())
+                .build()?
+        };
+        self.current_writer = Some(current_writer);
+        self.current_row_num = 0;
+        self.current_location = location;
+        Ok(())
+    }
+}

--- a/icelake/src/io/rolling_writer.rs
+++ b/icelake/src/io/rolling_writer.rs
@@ -1,5 +1,4 @@
-//! A writer capable of splitting incoming data into multiple files within one spec/partition based on the target file size.
-//! Thit writer is used by data_file writer or delete writer. It should not be used directly.
+//! A module provide `RollingWriter`.
 use arrow_array::RecordBatch;
 use parquet::file::properties::{WriterProperties, WriterVersion};
 use std::sync::Arc;
@@ -20,6 +19,8 @@ pub(crate) struct FileMetaData {
 
 /// A writer capable of splitting incoming data into multiple files within one spec/partition based on the target file size.
 /// When complete, it will return a list of `FileMetaData`.
+/// This writer should be used by specific content writer(`DataFileWriter` and `PositionDeleteFileWriter`), they should convert
+/// `FileMetaData` to specific `DataFile`.
 pub(crate) struct RollingWriter {
     operator: Operator,
     location_generator: Arc<DataFileLocationGenerator>,


### PR DESCRIPTION
This PR only support the writer write into a file, we also need more high level writer:
1. partition writer: split the delete op into different partition. 
2. sort writer: sort the delete op in the same partition. (This is optional, user can choose to use writer in this PR directly if they have sorted the op).

They will be completed later.