### PR TITLE
refactor: support PartitionSplitter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ arrow-row = { version = ">=46" }
 arrow-buffer = { version = ">=46" }
 arrow-arith = { version = ">=46" }
 arrow-csv = { version = ">=46" }
+arrow-cast = { version = ">=46" }
 bytes = "1"
 opendal = ">=0.37, <0.40"
 uuid = { version = "1", features = ["v4"] }

--- a/icelake/Cargo.toml
+++ b/icelake/Cargo.toml
@@ -17,6 +17,7 @@ arrow-select = { workspace = true }
 arrow-row = { workspace = true }
 arrow-arith = { workspace = true }
 arrow-buffer = { workspace = true }
+arrow-cast = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
 opendal = { workspace = true }

--- a/icelake/src/io/task_writer.rs
+++ b/icelake/src/io/task_writer.rs
@@ -6,21 +6,13 @@ use super::location_generator;
 use crate::config::TableConfigRef;
 use crate::error::Result;
 use crate::io::location_generator::DataFileLocationGenerator;
-use crate::types::BoxedTransformFunction;
+use crate::types::Any;
 use crate::types::PartitionSpec;
-use crate::types::{create_transform_function, DataFile, TableMetadata};
-use crate::types::{struct_to_anyvalue_array_with_type, Any, AnyValue};
-use crate::Error;
-use crate::ErrorKind;
-use arrow_array::ArrayRef;
+use crate::types::PartitionSplitter;
+use crate::types::{DataFile, TableMetadata};
 use arrow_array::RecordBatch;
-use arrow_array::{Array, BooleanArray, StructArray};
-use arrow_row::{OwnedRow, RowConverter, SortField};
-use arrow_schema::DataType;
-use arrow_schema::Field;
-use arrow_schema::Fields;
+use arrow_row::OwnedRow;
 use arrow_schema::SchemaRef as ArrowSchemaRef;
-use arrow_select::filter::filter_record_batch;
 use opendal::Operator;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
@@ -179,71 +171,17 @@ impl UnpartitionedWriter {
 
 /// Partition task writer
 pub struct PartitionedWriter {
-    schema: ArrowSchemaRef,
     operator: Operator,
     table_location: String,
     location_generator: Arc<DataFileLocationGenerator>,
-    /// Paritition fields used to compute:
-    /// - Vec<usize>: index vector of the source column
-    /// - String: partition field name
-    /// - BoxedTransformFunction: transform function
-    partition_fields: Vec<(Vec<usize>, String, BoxedTransformFunction)>,
-    /// Partition value type
-    partition_type: Any,
     table_config: TableConfigRef,
-    groups: HashMap<OwnedRow, PartitionGroup>,
-}
+    schema: ArrowSchemaRef,
 
-/// Each partition group corresponds to partition value.
-struct PartitionGroup {
-    /// The parition_array have only one element which it's the partition value.
-    pub partition_array: StructArray,
-    /// Row with same partition value will be written to the same data file writer.
-    pub writer: DataFileWriter,
+    writers: HashMap<OwnedRow, DataFileWriter>,
+    partition_splitter: PartitionSplitter,
 }
 
 impl PartitionedWriter {
-    /// Fetch the column index vector of the column id (We store it in Field of arrow as dict id).
-    /// e.g.
-    /// struct<struct<x:1,y:2>,z:3>
-    /// for source column id 2,
-    /// you will get the source column index vector [1,0]
-    fn fetch_column_index(fields: &Fields, index_vec: &mut Vec<usize>, col_id: i64) {
-        for (pos, field) in fields.iter().enumerate() {
-            let id: i64 = field
-                .metadata()
-                .get("column_id")
-                .expect("column_id must be set")
-                .parse()
-                .expect("column_id must can be parse as i64");
-            if col_id == id {
-                index_vec.push(pos);
-                return;
-            }
-            if let DataType::Struct(inner) = field.data_type() {
-                Self::fetch_column_index(inner, index_vec, col_id);
-                if !index_vec.is_empty() {
-                    index_vec.push(pos);
-                    return;
-                }
-            }
-        }
-    }
-
-    fn get_column_by_index_vec(batch: &RecordBatch, index_vec: &[usize]) -> ArrayRef {
-        let mut rev_iterator = index_vec.iter().rev();
-        let mut array = batch.column(*rev_iterator.next().unwrap()).clone();
-        for idx in rev_iterator {
-            array = array
-                .as_any()
-                .downcast_ref::<StructArray>()
-                .unwrap()
-                .column(*idx)
-                .clone();
-        }
-        array
-    }
-
     /// Create a new `PartitionedWriter`.
     pub fn new(
         schema: ArrowSchemaRef,
@@ -254,183 +192,57 @@ impl PartitionedWriter {
         operator: Operator,
         table_config: TableConfigRef,
     ) -> Result<Self> {
-        let partition_fields = partition_spec
-            .fields
-            .iter()
-            .map(|field| {
-                let transform = create_transform_function(&field.transform)?;
-                let mut index_vec = vec![];
-                Self::fetch_column_index(
-                    schema.fields(),
-                    &mut index_vec,
-                    field.source_column_id as i64,
-                );
-                if index_vec.is_empty() {
-                    return Err(Error::new(
-                        ErrorKind::IcebergDataInvalid,
-                        format!("Can't find source column id: {}", field.source_column_id),
-                    ));
-                }
-                Ok((index_vec, field.name.clone(), transform))
-            })
-            .collect::<Result<Vec<_>>>()?;
         Ok(Self {
-            schema,
             operator,
             table_location,
             location_generator: location_generator.into(),
-            partition_fields,
-            partition_type,
             table_config,
-            groups: HashMap::new(),
+            writers: HashMap::new(),
+            partition_splitter: PartitionSplitter::new(partition_spec, &schema, partition_type)?,
+            schema,
         })
-    }
-
-    /// This function do two things:
-    /// 1. Partition the batch by partition spec.
-    /// 2. Create the partition group if not exist.
-    ///
-    /// # TODO
-    /// Mix up two thing in one function may be not a good idea.
-    /// The reason do that is we need to use the partition info in step 1 when we create the
-    /// partition group. To avoid data copy, we do that in one function. We may need to refactor
-    /// this function in the future. Also the name of this function may not be a good choice.
-    async fn split_by_partition(
-        &mut self,
-        batch: &RecordBatch,
-    ) -> Result<HashMap<OwnedRow, RecordBatch>> {
-        let value_array = Arc::new(StructArray::from(
-            self.partition_fields
-                .iter()
-                .map(|(index_vec, field_name, transform)| {
-                    let array = Self::get_column_by_index_vec(batch, index_vec);
-                    let array = transform.transform(array)?;
-                    let field = Arc::new(Field::new(
-                        field_name.clone(),
-                        array.data_type().clone(),
-                        true,
-                    ));
-                    Ok((field, array))
-                })
-                .collect::<Result<Vec<_>>>()?,
-        ));
-
-        let mut row_converter = RowConverter::new(vec![SortField::new(
-            value_array.data_type().clone(),
-        )])
-        .map_err(|e| crate::error::Error::new(crate::ErrorKind::ArrowError, format!("{}", e)))?;
-        let rows = row_converter
-            .convert_columns(&[value_array.clone()])
-            .map_err(|e| {
-                crate::error::Error::new(crate::ErrorKind::ArrowError, format!("{}", e))
-            })?;
-
-        // Group the batch by row value.
-        let mut group_ids = HashMap::new();
-        rows.into_iter().enumerate().for_each(|(row_id, row)| {
-            group_ids.entry(row.owned()).or_insert(vec![]).push(row_id);
-        });
-
-        // Create the partition group if not exist.
-        for (row, row_ids) in group_ids.iter() {
-            let row_id = row_ids[0];
-            if let Entry::Vacant(entry) = self.groups.entry(row.clone()) {
-                let partition_array = value_array.slice(row_id, 1);
-                let writer = DataFileWriter::try_new(
-                    self.operator.clone(),
-                    self.table_location.clone(),
-                    self.location_generator.clone(),
-                    self.schema.clone(),
-                    self.table_config.clone(),
-                )
-                .await?;
-                entry.insert(PartitionGroup {
-                    partition_array,
-                    writer,
-                });
-            }
-        }
-
-        // Partition the batch with same partition partition_values
-        let mut partition_batches = HashMap::new();
-        for (row, row_ids) in group_ids.into_iter() {
-            // generate the bool filter array from column_ids
-            let filter_array: BooleanArray = {
-                let mut filter = vec![false; batch.num_rows()];
-                row_ids.into_iter().for_each(|row_id| {
-                    filter[row_id] = true;
-                });
-                filter.into()
-            };
-
-            // filter the RecordBatch
-            partition_batches.insert(
-                row.clone(),
-                filter_record_batch(batch, &filter_array)
-                    .expect("We should guarantee the filter array is valid"),
-            );
-        }
-
-        Ok(partition_batches)
     }
 
     /// Write a record batch using data file writer.
     /// It will split the batch by partition spec and write the batch to different data file writer.
     pub async fn write(&mut self, batch: &RecordBatch) -> Result<()> {
-        let split_batch = self.split_by_partition(batch).await?;
+        let split_batch = self.partition_splitter.split_by_partition(batch).await?;
 
-        for (partition_values, batch) in split_batch.into_iter() {
-            self.groups
-                .get_mut(&partition_values)
-                .expect(
-                    "self.split_by_partition should create the new partition group if not exists",
-                )
-                .writer
-                .write(batch)
-                .await?;
+        for (row, batch) in split_batch.into_iter() {
+            match self.writers.entry(row) {
+                Entry::Occupied(mut writer) => {
+                    writer.get_mut().write(batch).await?;
+                }
+                Entry::Vacant(writer) => {
+                    writer
+                        .insert(
+                            DataFileWriter::try_new(
+                                self.operator.clone(),
+                                self.table_location.clone(),
+                                self.location_generator.clone(),
+                                self.schema.clone(),
+                                self.table_config.clone(),
+                            )
+                            .await?,
+                        )
+                        .write(batch)
+                        .await?;
+                }
+            }
         }
-
         Ok(())
     }
 
     /// Complete the write and return the data files.
     pub async fn close(self) -> Result<Vec<DataFile>> {
         let mut res = vec![];
-        for (
-            _,
-            PartitionGroup {
-                partition_array,
-                writer,
-            },
-        ) in self.groups.into_iter()
-        {
-            // Convert the partition array to partition value.
-            let value = {
-                // # NOTE
-                // We should guarantee that partition array type is consistent with partition_type.
-                // Other wise, struct_to_anyvalue_array_with_type will return the error.
-                let mut array = struct_to_anyvalue_array_with_type(
-                    &partition_array,
-                    self.partition_type.clone(),
-                )?;
-                // We guarantee the partition array only has one value.
-                assert!(array.len() == 1);
-                let value = array
-                    .pop()
-                    .unwrap()
-                    .expect("Partition Value is alway valid");
-                // cast to StructValue
-                if let AnyValue::Struct(v) = value {
-                    v
-                } else {
-                    unreachable!("Partition value should be struct value")
-                }
-            };
+        let mut partition_values = self.partition_splitter.partition_values();
+        for (row, writer) in self.writers.into_iter() {
             let data_file_builders = writer.close().await?;
             // Update the partition value in data file.
             res.extend(data_file_builders.into_iter().map(|data_file_builder| {
                 data_file_builder
-                    .with_partition_value(value.clone())
+                    .with_partition_value(partition_values.remove(&row).unwrap())
                     .build()
             }));
         }

--- a/icelake/src/types/mod.rs
+++ b/icelake/src/types/mod.rs
@@ -15,3 +15,6 @@ mod to_avro;
 
 mod transform;
 pub use transform::*;
+
+mod partition_splitter;
+pub use partition_splitter::*;

--- a/icelake/src/types/partition_splitter.rs
+++ b/icelake/src/types/partition_splitter.rs
@@ -1,0 +1,203 @@
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    sync::Arc,
+};
+
+use super::{create_transform_function, Any, BoxedTransformFunction, PartitionSpec};
+use crate::types::{struct_to_anyvalue_array_with_type, AnyValue, StructValue};
+use crate::{Error, ErrorKind, Result};
+use arrow_array::{Array, ArrayRef, BooleanArray, RecordBatch, StructArray};
+use arrow_row::{OwnedRow, RowConverter, SortField};
+use arrow_schema::{DataType, Field, Fields, SchemaRef};
+use arrow_select::filter::filter_record_batch;
+
+/// `PartitionSplitter` is used to splite a given record according partition value.
+pub struct PartitionSplitter {
+    field_infos: Vec<PartitionFieldComputeInfo>,
+    partition_value: HashMap<OwnedRow, StructValue>,
+    partition_type: Any,
+}
+
+/// Internal info used to compute single partition field .
+struct PartitionFieldComputeInfo {
+    pub index_vec: Vec<usize>,
+    pub field_name: String,
+    pub transform: BoxedTransformFunction,
+}
+
+impl PartitionSplitter {
+    /// Create a new `PartitionSplitter`.
+    pub fn new(
+        partition_spec: &PartitionSpec,
+        schema: &SchemaRef,
+        partition_type: Any,
+    ) -> Result<Self> {
+        let field_infos = partition_spec
+            .fields
+            .iter()
+            .map(|field| {
+                let transform = create_transform_function(&field.transform)?;
+                let mut index_vec = vec![];
+                Self::fetch_column_index(
+                    schema.fields(),
+                    &mut index_vec,
+                    field.source_column_id as i64,
+                );
+                if index_vec.is_empty() {
+                    return Err(Error::new(
+                        ErrorKind::IcebergDataInvalid,
+                        format!("Can't find source column id: {}", field.source_column_id),
+                    ));
+                }
+                Ok(PartitionFieldComputeInfo {
+                    index_vec,
+                    field_name: field.name.clone(),
+                    transform,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Self {
+            field_infos,
+            partition_value: HashMap::new(),
+            partition_type,
+        })
+    }
+
+    /// Fetch the column index vector of the column id (We store it in Field of arrow as dict id).
+    /// e.g.
+    /// struct<struct<x:1,y:2>,z:3>
+    /// for source column id 2,
+    /// you will get the source column index vector [1,0]
+    fn fetch_column_index(fields: &Fields, index_vec: &mut Vec<usize>, col_id: i64) {
+        for (pos, field) in fields.iter().enumerate() {
+            let id: i64 = field
+                .metadata()
+                .get("column_id")
+                .expect("column_id must be set")
+                .parse()
+                .expect("column_id must can be parse as i64");
+            if col_id == id {
+                index_vec.push(pos);
+                return;
+            }
+            if let DataType::Struct(inner) = field.data_type() {
+                Self::fetch_column_index(inner, index_vec, col_id);
+                if !index_vec.is_empty() {
+                    index_vec.push(pos);
+                    return;
+                }
+            }
+        }
+    }
+
+    /// This function do two things:
+    /// 1. Partition the batch by partition spec.
+    /// 2. Create the partition value.
+    pub async fn split_by_partition(
+        &mut self,
+        batch: &RecordBatch,
+    ) -> Result<HashMap<OwnedRow, RecordBatch>> {
+        let value_array = Arc::new(StructArray::from(
+            self.field_infos
+                .iter()
+                .map(
+                    |PartitionFieldComputeInfo {
+                         index_vec,
+                         field_name,
+                         transform,
+                     }| {
+                        let array = Self::get_column_by_index_vec(batch, index_vec);
+                        let array = transform.transform(array)?;
+                        let field = Arc::new(Field::new(
+                            field_name.clone(),
+                            array.data_type().clone(),
+                            true,
+                        ));
+                        Ok((field, array))
+                    },
+                )
+                .collect::<Result<Vec<_>>>()?,
+        ));
+
+        let mut row_converter = RowConverter::new(vec![SortField::new(
+            value_array.data_type().clone(),
+        )])
+        .map_err(|e| crate::error::Error::new(crate::ErrorKind::ArrowError, format!("{}", e)))?;
+        let rows = row_converter
+            .convert_columns(&[value_array.clone()])
+            .map_err(|e| {
+                crate::error::Error::new(crate::ErrorKind::ArrowError, format!("{}", e))
+            })?;
+
+        // Group the batch by row value.
+        let mut group_ids = HashMap::new();
+        rows.into_iter().enumerate().for_each(|(row_id, row)| {
+            group_ids.entry(row.owned()).or_insert(vec![]).push(row_id);
+        });
+
+        // Create the partition group if not exist.
+        for (row, row_ids) in group_ids.iter() {
+            let row_id = row_ids[0];
+            if let Entry::Vacant(entry) = self.partition_value.entry(row.clone()) {
+                let partition_array = value_array.slice(row_id, 1);
+                let mut array = struct_to_anyvalue_array_with_type(
+                    &partition_array,
+                    self.partition_type.clone(),
+                )?;
+                // We guarantee the partition array only has one value.
+                assert!(array.len() == 1);
+                let value = array
+                    .pop()
+                    .unwrap()
+                    .expect("Partition Value is alway valid");
+                // cast to StructValue
+                if let AnyValue::Struct(v) = value {
+                    entry.insert(v);
+                } else {
+                    unreachable!("Partition value should be struct value")
+                }
+            }
+        }
+
+        // Partition the batch with same partition partition_values
+        let mut partition_batches = HashMap::new();
+        for (row, row_ids) in group_ids.into_iter() {
+            // generate the bool filter array from column_ids
+            let filter_array: BooleanArray = {
+                let mut filter = vec![false; batch.num_rows()];
+                row_ids.into_iter().for_each(|row_id| {
+                    filter[row_id] = true;
+                });
+                filter.into()
+            };
+
+            // filter the RecordBatch
+            partition_batches.insert(
+                row.clone(),
+                filter_record_batch(batch, &filter_array)
+                    .expect("We should guarantee the filter array is valid"),
+            );
+        }
+
+        Ok(partition_batches)
+    }
+
+    fn get_column_by_index_vec(batch: &RecordBatch, index_vec: &[usize]) -> ArrayRef {
+        let mut rev_iterator = index_vec.iter().rev();
+        let mut array = batch.column(*rev_iterator.next().unwrap()).clone();
+        for idx in rev_iterator {
+            array = array
+                .as_any()
+                .downcast_ref::<StructArray>()
+                .unwrap()
+                .column(*idx)
+                .clone();
+        }
+        array
+    }
+
+    /// Get the partition value.
+    pub fn partition_values(self) -> HashMap<OwnedRow, StructValue> {
+        self.partition_value
+    }
+}

--- a/icelake/tests/rest_catalog_tests.rs
+++ b/icelake/tests/rest_catalog_tests.rs
@@ -53,7 +53,7 @@ impl TestFixture2 {
             ("iceberg.table.io.secret_access_key", "password".to_string()),
         ])
         .into_iter()
-        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .map(|(k, v)| (k.to_string(), v))
         .collect();
 
         load_catalog(&configs).await.unwrap()


### PR DESCRIPTION
After we introduce more writer, we need to reuse partition logic. This PR seperate the partition logic by introduce a PartitionSplitter. We can call the interface in it to split the record batch into multiple group.

`fn split_by_partition(batch) -> HashMap<OwnedRow,batch>`