### PR TITLE
feat: Allow reuse storage catalog

### DIFF
--- a/icelake/examples/read_iceberg_table.rs
+++ b/icelake/examples/read_iceberg_table.rs
@@ -1,13 +1,13 @@
 use std::env;
 
 use anyhow::Result;
-use icelake::catalog::StorageCatalog;
+use icelake::catalog::{IcebergStorageCatalog};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
     let table_uri = format!("{}/../testdata/simple_table", env!("CARGO_MANIFEST_DIR"));
 
-    let table = StorageCatalog::load_table(table_uri.as_str()).await?;
+    let table = IcebergStorageCatalog::load_table(table_uri.as_str()).await?;
     println!("{:?}", table.current_table_metadata());
     Ok(())
 }

--- a/icelake/examples/read_iceberg_table.rs
+++ b/icelake/examples/read_iceberg_table.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 use anyhow::Result;
-use icelake::catalog::{IcebergStorageCatalog};
+use icelake::catalog::IcebergStorageCatalog;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {

--- a/icelake/src/catalog/io.rs
+++ b/icelake/src/catalog/io.rs
@@ -20,36 +20,59 @@ pub const OP_ARGS_ACCESS_KEY: &str = "access_key_id";
 /// s3 access secret
 pub const OP_ARGS_ACCESS_SECRET: &str = "secret_access_key";
 
-/// Args for creating opendal operator
-#[derive(Debug, Clone)]
-pub struct OperatorArgs {
-    scheme: Scheme,
-    args: HashMap<String, String>,
+
+/// OperatorCreator is used to create an opendal::Operator.
+///
+/// OpenDAL doesn't support checkout sub dir yet, thus we need to support create a new operator
+/// with sub dir. There is an ongoing issue at upstream but no progress yet: https://github.com/apache/incubator-opendal/issues/3151
+/// Instead of waiting for upstream, we can create a new operator with sub dir by ourselves.
+/// We can decide to migrate to upstream's solution in the future.
+///
+/// Besides, our users of icelake could implement their config parsers that not fully compatible
+/// with iceberg based config like `iceberg.io.xxx`. So we make it a trait instead to allow users
+/// to implement their own `OperatorCreator` instead a full storage catalog.
+pub trait OperatorCreator: Send + Sync + 'static {
+    /// Create an operator with existing config.
+    ///
+    /// Implementor could cache the operator instead to avoid creating it every time.
+    fn create(&self) -> Result<Operator>;
+
+    /// Create an operator with sub dir.
+    fn create_with_subdir(&self, path: &str) -> Result<Operator>;
 }
 
-impl OperatorArgs {
+/// Args for creating opendal operator
+#[derive(Debug, Clone)]
+pub struct IcebergTableIoArgs {
+    scheme: Scheme,
+    args: HashMap<String, String>,
+
+    op: Operator,
+}
+
+impl IcebergTableIoArgs {
     /// Create a builder with `Scheme`
-    pub fn builder(scheme: Scheme) -> OperatorArgsBuilder {
-        OperatorArgsBuilder(OperatorArgs {
+    pub fn builder(scheme: Scheme) -> IcebergTableIoArgsBuilder {
+        IcebergTableIoArgsBuilder {
             scheme,
             args: HashMap::new(),
-        })
+        }
     }
 
     /// Creates a builder from path.
-    pub fn builder_from_path(path: &str) -> Result<OperatorArgsBuilder> {
+    pub fn builder_from_path(path: &str) -> Result<IcebergTableIoArgsBuilder> {
         if path.starts_with('/') {
             // Local file path such as: /tmp
-            return Ok(OperatorArgs::builder(Scheme::Fs).with_arg(OP_ARGS_ROOT, path));
+            return Ok(IcebergTableIoArgs::builder(Scheme::Fs).with_arg(OP_ARGS_ROOT, path));
         }
 
         let url = Url::parse(path)?;
 
         let op = match url.scheme() {
             "file" => {
-                OperatorArgs::builder(Scheme::Fs).with_arg(OP_ARGS_ROOT, url.path().to_string())
+                IcebergTableIoArgs::builder(Scheme::Fs).with_arg(OP_ARGS_ROOT, url.path().to_string())
             }
-            "s3" | "s3a" => OperatorArgs::builder(Scheme::S3)
+            "s3" | "s3a" => IcebergTableIoArgs::builder(Scheme::S3)
                 .with_arg(OP_ARGS_ROOT, url.path().to_string())
                 .with_arg(
                     OP_ARGS_BUCKET,
@@ -75,52 +98,58 @@ impl OperatorArgs {
 }
 
 /// Operator args builder.
-pub struct OperatorArgsBuilder(OperatorArgs);
+pub struct IcebergTableIoArgsBuilder {
+    scheme: Scheme,
+    args: HashMap<String, String>,
+}
 
-impl OperatorArgsBuilder {
+impl IcebergTableIoArgsBuilder {
     /// Add arg.
     pub fn with_arg(mut self, key: impl ToString, value: impl ToString) -> Self {
-        self.0.args.insert(key.to_string(), value.to_string());
+        self.args.insert(key.to_string(), value.to_string());
         self
     }
 
     /// Add all args
     pub fn with_args(mut self, args: impl Iterator<Item = (impl ToString, impl ToString)>) -> Self {
-        self.0
+        self
             .args
             .extend(args.map(|(k, v)| (k.to_string(), v.to_string())));
         self
     }
 
     /// Build arg.
-    pub fn build(self) -> OperatorArgs {
-        self.0
+    pub fn build(self) -> Result<IcebergTableIoArgs> {
+        let op = Operator::via_map(self.scheme, self.args.clone())?;
+        
+        Ok( IcebergTableIoArgs {
+            scheme: self.scheme,
+            args: self.args,
+            op,
+        })
     }
 }
 
-impl TryFrom<&OperatorArgs> for Operator {
-    type Error = Error;
+impl OperatorCreator for IcebergTableIoArgs {
+    fn create(&self) -> Result<Operator> {
+        Ok(Operator::via_map(self.scheme, self.args.clone())?)
+    }
 
-    fn try_from(args: &OperatorArgs) -> Result<Self> {
-        Ok(Operator::via_map(args.scheme, args.args.clone())?)
+    fn create_with_subdir(&self, path: &str) -> Result<Operator> {
+        let scheme= self.scheme;
+        let mut args= self.args.clone();
+
+        let new_root = format!("{}/{path}", args.get(OP_ARGS_ROOT).cloned().unwrap_or_default());
+        args.insert(OP_ARGS_ROOT.to_string(), new_root);
+
+        Ok(Operator::via_map(scheme, args.clone())?)
     }
 }
 
-impl OperatorArgs {
-    /// Creates a subdir of current operator args.
-    pub fn sub_dir(&self, sub_dir: &str) -> Result<Self> {
-        let op = Operator::try_from(self)?;
-
-        let mut new_args = self.clone();
-        let new_root = format!("{}/{sub_dir}", op.info().root());
-        new_args.args.insert(OP_ARGS_ROOT.to_string(), new_root);
-
-        Ok(new_args)
-    }
-
+impl IcebergTableIoArgs {
     /// Returns root path of current operator args.
     pub fn url(&self) -> Result<String> {
-        let op = Operator::try_from(self)?;
+        let op = self.create()?;
         Ok(format!(
             "{}://{}/{}",
             self.scheme,

--- a/icelake/src/catalog/io.rs
+++ b/icelake/src/catalog/io.rs
@@ -20,7 +20,6 @@ pub const OP_ARGS_ACCESS_KEY: &str = "access_key_id";
 /// s3 access secret
 pub const OP_ARGS_ACCESS_SECRET: &str = "secret_access_key";
 
-
 /// OperatorCreator is used to create an opendal::Operator.
 ///
 /// OpenDAL doesn't support checkout sub dir yet, thus we need to support create a new operator
@@ -69,9 +68,8 @@ impl IcebergTableIoArgs {
         let url = Url::parse(path)?;
 
         let op = match url.scheme() {
-            "file" => {
-                IcebergTableIoArgs::builder(Scheme::Fs).with_arg(OP_ARGS_ROOT, url.path().to_string())
-            }
+            "file" => IcebergTableIoArgs::builder(Scheme::Fs)
+                .with_arg(OP_ARGS_ROOT, url.path().to_string()),
             "s3" | "s3a" => IcebergTableIoArgs::builder(Scheme::S3)
                 .with_arg(OP_ARGS_ROOT, url.path().to_string())
                 .with_arg(
@@ -112,8 +110,7 @@ impl IcebergTableIoArgsBuilder {
 
     /// Add all args
     pub fn with_args(mut self, args: impl Iterator<Item = (impl ToString, impl ToString)>) -> Self {
-        self
-            .args
+        self.args
             .extend(args.map(|(k, v)| (k.to_string(), v.to_string())));
         self
     }
@@ -121,8 +118,8 @@ impl IcebergTableIoArgsBuilder {
     /// Build arg.
     pub fn build(self) -> Result<IcebergTableIoArgs> {
         let op = Operator::via_map(self.scheme, self.args.clone())?;
-        
-        Ok( IcebergTableIoArgs {
+
+        Ok(IcebergTableIoArgs {
             scheme: self.scheme,
             args: self.args,
             op,
@@ -136,10 +133,13 @@ impl OperatorCreator for IcebergTableIoArgs {
     }
 
     fn create_with_subdir(&self, path: &str) -> Result<Operator> {
-        let scheme= self.scheme;
-        let mut args= self.args.clone();
+        let scheme = self.scheme;
+        let mut args = self.args.clone();
 
-        let new_root = format!("{}/{path}", args.get(OP_ARGS_ROOT).cloned().unwrap_or_default());
+        let new_root = format!(
+            "{}/{path}",
+            args.get(OP_ARGS_ROOT).cloned().unwrap_or_default()
+        );
         args.insert(OP_ARGS_ROOT.to_string(), new_root);
 
         Ok(Operator::via_map(scheme, args.clone())?)

--- a/icelake/src/catalog/mod.rs
+++ b/icelake/src/catalog/mod.rs
@@ -461,7 +461,7 @@ pub async fn load_catalog(configs: &HashMap<String, String>) -> Result<CatalogRe
 
     match catalog_type.as_str() {
         "storage" => Ok(Arc::new(
-            StorageCatalog::new(base_catalog_config, configs).await?,
+            StorageCatalog::from_config(base_catalog_config, configs).await?,
         )),
         "rest" => Ok(Arc::new(
             RestCatalog::new(base_catalog_config, configs).await?,

--- a/icelake/src/catalog/rest.rs
+++ b/icelake/src/catalog/rest.rs
@@ -21,7 +21,7 @@ use crate::{
 use self::_models::{CommitTableRequest, ListTablesResponse, LoadTableResult};
 
 use super::{BaseCatalogConfig, Catalog, UpdateTable};
-use crate::catalog::{CATALOG_CONFIG_PREFIX, OperatorCreator};
+use crate::catalog::{OperatorCreator, CATALOG_CONFIG_PREFIX};
 use crate::error::Result;
 
 const PATH_V1: &str = "v1";
@@ -95,8 +95,9 @@ impl Catalog for RestCatalog {
 
         let table_metadata = TableMetadata::try_from(resp.metadata)?;
 
-        let iceberg_io_args =  IcebergTableIoArgs::builder_from_path(&table_metadata.location)?
-            .with_args(self.config.base_config.table_io_configs.iter()).build()?;
+        let iceberg_io_args = IcebergTableIoArgs::builder_from_path(&table_metadata.location)?
+            .with_args(self.config.base_config.table_io_configs.iter())
+            .build()?;
         let table_op = iceberg_io_args.create()?;
 
         Ok(

--- a/icelake/src/catalog/storage.rs
+++ b/icelake/src/catalog/storage.rs
@@ -17,33 +17,243 @@ use crate::{
 };
 
 use super::{
-    load_catalog, BaseCatalogConfig, Catalog, OperatorArgs, UpdateTable, CATALOG_NAME, CATALOG_TYPE,
+    load_catalog, BaseCatalogConfig, Catalog, IcebergTableIoArgs, UpdateTable, CATALOG_NAME, CATALOG_TYPE,
 };
-use crate::catalog::CATALOG_CONFIG_PREFIX;
+use crate::catalog::{CATALOG_CONFIG_PREFIX, OperatorCreator};
 use crate::error::Result;
 
 /// Configuration for storage config.
-pub struct StorageCatalogConfig {
+pub struct StorageCatalogConfig<O: OperatorCreator> {
     warehouse: String,
     base_catalog_config: BaseCatalogConfig,
-    op_args: OperatorArgs,
+    op_args: O,
 }
 
 /// File system catalog.
-pub struct StorageCatalog {
-    op: Operator,
-    config: StorageCatalogConfig,
+pub struct StorageCatalog<O: OperatorCreator> {
+    warehouse: String,
+    catalog_config: BaseCatalogConfig,
+
+    operator_creator: O,
 }
 
+impl<O: OperatorCreator> StorageCatalog<O> {
+    /// Create a new storage catalog with given warehouse and operator creator.
+    pub fn new(warehouse: &str, operator_creator: O) -> Self {
+        StorageCatalog {
+            warehouse: warehouse.to_string(),
+            catalog_config: BaseCatalogConfig {
+                name: "storage".to_string(),
+                ..Default::default()
+            },
+            operator_creator,
+        }
+    }
+
+    /// Create a new storage catalog with given catalog config.
+    pub fn with_catalog_config(warehouse: &str, operator_creator: O, catalog_config: BaseCatalogConfig) -> Self {
+        StorageCatalog {
+            warehouse: warehouse.to_string(),
+            catalog_config,
+            operator_creator,
+        }
+    }
+
+    #[inline]
+    fn operator(&self) -> Result<Operator> {
+        self.operator_creator.create()
+    }
+
+    async fn is_table_dir(&self, table_name: &TableIdentifier) -> Result<bool> {
+        let table_metadata_dir = format!("{}/{}", table_name.to_path()?, META_ROOT_PATH);
+        if !self.operator()?.is_exist(&table_metadata_dir).await? {
+            return Ok(false);
+        }
+
+        let mut ds = self
+            .operator_creator.create()?
+            .lister_with(&table_metadata_dir)
+            .metakey(Metakey::Mode)
+            .await?;
+        while let Some(de) = ds.try_next().await? {
+            let meta = de.metadata();
+
+            match meta.mode() {
+                EntryMode::FILE if de.name().ends_with(METADATA_FILE_EXTENSION) => {
+                    return Ok(true);
+                }
+                _ => {}
+            }
+        }
+
+        Ok(false)
+    }
+
+    /// Read version hint of table.
+    ///
+    /// `table_path`: relative path of table dir under warehouse root.
+    async fn read_version_hint(&self, table_path: &str) -> Result<i32> {
+        let content = self
+            .operator_creator.create()?
+            .read(format!("{table_path}/metadata/version-hint.text").as_str())
+            .await?;
+        let version_hint = String::from_utf8(content).map_err(|err| {
+            Error::new(
+                crate::ErrorKind::IcebergDataInvalid,
+                format!("Fail to covert version_hint from utf8 to string: {}", err),
+            )
+        })?;
+
+        version_hint.parse().map_err(|e| {
+            Error::new(
+                crate::ErrorKind::IcebergDataInvalid,
+                format!("parse version hint failed: {}", e),
+            )
+        })
+    }
+
+    /// Read table metadata of the given version.
+    async fn read_table_metadata(&self, path: &str) -> Result<types::TableMetadata> {
+        let content = self.operator()?.read(path).await?;
+
+        let metadata = types::parse_table_metadata(&content)?;
+
+        Ok(metadata)
+    }
+
+    /// List all paths of table metadata files.
+    ///
+    /// The returned paths are sorted by name.
+    ///
+    /// TODO: we can imporve this by only fetch the latest metadata.
+    ///
+    /// `table_path`: relative path of table dir under warehouse root.
+    async fn list_table_metadata_paths(&self, table_path: &str) -> Result<Vec<String>> {
+        let mut lister = self
+            .operator_creator.create()?
+            .lister(format!("{table_path}/metadata/").as_str())
+            .await
+            .map_err(|err| {
+                Error::new(
+                    crate::ErrorKind::Unexpected,
+                    format!("list metadata failed: {}", err),
+                )
+            })?;
+
+        let mut paths = vec![];
+
+        while let Some(entry) = lister.next().await {
+            let entry = entry.map_err(|err| {
+                Error::new(
+                    crate::ErrorKind::Unexpected,
+                    format!("list metadata entry failed: {}", err),
+                )
+            })?;
+
+            // Only push into paths if the entry is a metadata file.
+            if entry.path().ends_with(".metadata.json") {
+                paths.push(entry.path().to_string());
+            }
+        }
+
+        // Make the returned paths sorted by name.
+        paths.sort();
+
+        Ok(paths)
+    }
+
+    /// Check if version hint file exist.
+    ///
+    /// `table_path`: relative path of table dir under warehouse root.
+    async fn is_version_hint_exist(&self, table_path: &str) -> Result<bool> {
+        self.operator()?
+            .is_exist(format!("{table_path}/metadata/version-hint.text").as_str())
+            .await
+            .map_err(|e| {
+                Error::new(
+                    crate::ErrorKind::IcebergDataInvalid,
+                    format!("check if version hint exist failed: {}", e),
+                )
+            })
+    }
+
+    async fn commit_table(
+        &self,
+        table_path: &str,
+        next_version: i64,
+        next_metadata: TableMetadata,
+    ) -> Result<()> {
+        let tmp_metadata_file_path = format!(
+            "{table_path}/metadata/{}{METADATA_FILE_EXTENSION}",
+            Uuid::new_v4()
+        );
+
+        let final_metadata_file_path =
+            format!("{table_path}/metadata/v{next_version}{METADATA_FILE_EXTENSION}");
+
+        log::debug!("Writing to temporary metadata file path: {tmp_metadata_file_path}");
+        self.operator()?
+            .write(
+                &tmp_metadata_file_path,
+                serialize_table_meta(next_metadata)?,
+            )
+            .await?;
+
+        log::debug!("Renaming temporary metadata file path [{tmp_metadata_file_path}] to final metadata file path [{final_metadata_file_path}]");
+        Self::rename(&self.operator()?, &tmp_metadata_file_path, &final_metadata_file_path).await?;
+        self.write_metadata_version_hint(next_version, table_path)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn write_metadata_version_hint(&self, version: i64, table_path: &str) -> Result<()> {
+        let tmp_version_hint_path =
+            format!("{table_path}/metadata/{}-version-hint.temp", Uuid::new_v4());
+        self.operator()?
+            .write(&tmp_version_hint_path, format!("{version}"))
+            .await?;
+
+        let final_version_hint_path = format!("{table_path}/metadata/{VERSION_HINT_FILENAME}");
+
+        self.operator()?.delete(final_version_hint_path.as_str()).await?;
+        log::debug!("Renaming temporary version hint file path [{tmp_version_hint_path}] to final metadata file path [{final_version_hint_path}]");
+        Self::rename(&self.operator()?, &tmp_version_hint_path, &final_version_hint_path).await?;
+
+        Ok(())
+    }
+
+    fn table_metadata_path(&self, table_path: &str, metadata_filename: &str) -> String {
+        format!("{table_path}/metadata/{metadata_filename}")
+    }
+
+    async fn rename(op: &Operator, src_path: &str, dest_path: &str) -> Result<()> {
+        let info = op.info();
+        if info.full_capability().rename {
+            Ok(op.rename(src_path, dest_path).await?)
+        } else {
+            op.copy(src_path, dest_path).await?;
+            op.delete(src_path).await?;
+            Ok(())
+        }
+    }
+
+    fn table_operator(&self, table_path: &str) -> Result<Operator> {
+        self.operator_creator.create_with_subdir(table_path)
+    }
+}
+
+
+
 #[async_trait]
-impl Catalog for StorageCatalog {
+impl<O: OperatorCreator> Catalog for StorageCatalog<O> {
     fn name(&self) -> &str {
-        &self.config.base_catalog_config.name
+        &self.catalog_config.name
     }
 
     async fn list_tables(self: Arc<Self>, ns: &Namespace) -> Result<Vec<TableIdentifier>> {
         let ns_path = ns.to_path()?;
-        let mut ds = self.op.lister(&ns_path).await?;
+        let mut ds = self.operator()?.lister(&ns_path).await?;
         let mut tables = vec![];
         while let Some(de) = ds.try_next().await? {
             let table_name = de.name();
@@ -141,9 +351,12 @@ impl Catalog for StorageCatalog {
     }
 }
 
-impl StorageCatalog {
+/// File system catalog with iceberg options.
+pub type IcebergStorageCatalog = StorageCatalog<IcebergTableIoArgs>;
+
+impl IcebergStorageCatalog {
     /// Creates a new storage catalog.
-    pub async fn new(
+    pub async fn from_config(
         base_config: BaseCatalogConfig,
         others: &HashMap<String, String>,
     ) -> Result<Self> {
@@ -156,19 +369,11 @@ impl StorageCatalog {
                 )
             })?;
 
-        let op_args = OperatorArgs::builder_from_path(warehouse)?
+        let op = IcebergTableIoArgs::builder_from_path(warehouse)?
             .with_args(base_config.table_io_configs.iter())
-            .build();
+            .build()?;
 
-        let op = Operator::try_from(&op_args)?;
-
-        let config = StorageCatalogConfig {
-            warehouse: warehouse.to_string(),
-            base_catalog_config: base_config,
-            op_args,
-        };
-
-        Ok(StorageCatalog { op, config })
+        Ok(StorageCatalog::with_catalog_config(warehouse, op, base_config))
     }
 
     /// Load table from path.
@@ -184,7 +389,7 @@ impl StorageCatalog {
     }
 
     /// Load table in warehouse.
-    pub async fn load_table_in(warehouse_path: &str, table_name: &str) -> Result<Table> {
+    pub(crate)  async fn load_table_in(warehouse_path: &str, table_name: &str) -> Result<Table> {
         let configs = HashMap::from([
             (CATALOG_NAME.to_string(), "demo".to_string()),
             (CATALOG_TYPE.to_string(), "storage".to_string()),
@@ -200,197 +405,8 @@ impl StorageCatalog {
             .load_table(&TableIdentifier::new(vec![table_name])?)
             .await
     }
-
-    /// Create filesystem catalog from operator args.
-    // pub async fn open(op_args: OperatorArgs) -> Result<StorageCatalog> {
-    //     let op = Operator::try_from(&op_args)?;
-
-    //     Ok(StorageCatalog {
-    //         name: "fs catalog".to_string(),
-    //         root_uri: op_args.url()?,
-    //         op_args,
-    //         op,
-    //     })
-    // }
-
-    async fn is_table_dir(&self, table_name: &TableIdentifier) -> Result<bool> {
-        let table_metadata_dir = format!("{}/{}", table_name.to_path()?, META_ROOT_PATH);
-        if !self.op.is_exist(&table_metadata_dir).await? {
-            return Ok(false);
-        }
-
-        let mut ds = self
-            .op
-            .lister_with(&table_metadata_dir)
-            .metakey(Metakey::Mode)
-            .await?;
-        while let Some(de) = ds.try_next().await? {
-            let meta = de.metadata();
-
-            match meta.mode() {
-                EntryMode::FILE if de.name().ends_with(METADATA_FILE_EXTENSION) => {
-                    return Ok(true);
-                }
-                _ => {}
-            }
-        }
-
-        Ok(false)
-    }
-
-    /// Read version hint of table.
-    ///
-    /// `table_path`: relative path of table dir under warehouse root.
-    async fn read_version_hint(&self, table_path: &str) -> Result<i32> {
-        let content = self
-            .op
-            .read(format!("{table_path}/metadata/version-hint.text").as_str())
-            .await?;
-        let version_hint = String::from_utf8(content).map_err(|err| {
-            Error::new(
-                crate::ErrorKind::IcebergDataInvalid,
-                format!("Fail to covert version_hint from utf8 to string: {}", err),
-            )
-        })?;
-
-        version_hint.parse().map_err(|e| {
-            Error::new(
-                crate::ErrorKind::IcebergDataInvalid,
-                format!("parse version hint failed: {}", e),
-            )
-        })
-    }
-
-    /// Read table metadata of the given version.
-    async fn read_table_metadata(&self, path: &str) -> Result<types::TableMetadata> {
-        let content = self.op.read(path).await?;
-
-        let metadata = types::parse_table_metadata(&content)?;
-
-        Ok(metadata)
-    }
-
-    /// List all paths of table metadata files.
-    ///
-    /// The returned paths are sorted by name.
-    ///
-    /// TODO: we can imporve this by only fetch the latest metadata.
-    ///
-    /// `table_path`: relative path of table dir under warehouse root.
-    async fn list_table_metadata_paths(&self, table_path: &str) -> Result<Vec<String>> {
-        let mut lister = self
-            .op
-            .lister(format!("{table_path}/metadata/").as_str())
-            .await
-            .map_err(|err| {
-                Error::new(
-                    crate::ErrorKind::Unexpected,
-                    format!("list metadata failed: {}", err),
-                )
-            })?;
-
-        let mut paths = vec![];
-
-        while let Some(entry) = lister.next().await {
-            let entry = entry.map_err(|err| {
-                Error::new(
-                    crate::ErrorKind::Unexpected,
-                    format!("list metadata entry failed: {}", err),
-                )
-            })?;
-
-            // Only push into paths if the entry is a metadata file.
-            if entry.path().ends_with(".metadata.json") {
-                paths.push(entry.path().to_string());
-            }
-        }
-
-        // Make the returned paths sorted by name.
-        paths.sort();
-
-        Ok(paths)
-    }
-
-    /// Check if version hint file exist.
-    ///
-    /// `table_path`: relative path of table dir under warehouse root.
-    async fn is_version_hint_exist(&self, table_path: &str) -> Result<bool> {
-        self.op
-            .is_exist(format!("{table_path}/metadata/version-hint.text").as_str())
-            .await
-            .map_err(|e| {
-                Error::new(
-                    crate::ErrorKind::IcebergDataInvalid,
-                    format!("check if version hint exist failed: {}", e),
-                )
-            })
-    }
-
-    async fn commit_table(
-        &self,
-        table_path: &str,
-        next_version: i64,
-        next_metadata: TableMetadata,
-    ) -> Result<()> {
-        let tmp_metadata_file_path = format!(
-            "{table_path}/metadata/{}{METADATA_FILE_EXTENSION}",
-            Uuid::new_v4()
-        );
-
-        let final_metadata_file_path =
-            format!("{table_path}/metadata/v{next_version}{METADATA_FILE_EXTENSION}");
-
-        log::debug!("Writing to temporary metadata file path: {tmp_metadata_file_path}");
-        self.op
-            .write(
-                &tmp_metadata_file_path,
-                serialize_table_meta(next_metadata)?,
-            )
-            .await?;
-
-        log::debug!("Renaming temporary metadata file path [{tmp_metadata_file_path}] to final metadata file path [{final_metadata_file_path}]");
-        Self::rename(&self.op, &tmp_metadata_file_path, &final_metadata_file_path).await?;
-        self.write_metadata_version_hint(next_version, table_path)
-            .await?;
-
-        Ok(())
-    }
-
-    async fn write_metadata_version_hint(&self, version: i64, table_path: &str) -> Result<()> {
-        let tmp_version_hint_path =
-            format!("{table_path}/metadata/{}-version-hint.temp", Uuid::new_v4());
-        self.op
-            .write(&tmp_version_hint_path, format!("{version}"))
-            .await?;
-
-        let final_version_hint_path = format!("{table_path}/metadata/{VERSION_HINT_FILENAME}");
-
-        self.op.delete(final_version_hint_path.as_str()).await?;
-        log::debug!("Renaming temporary version hint file path [{tmp_version_hint_path}] to final metadata file path [{final_version_hint_path}]");
-        Self::rename(&self.op, &tmp_version_hint_path, &final_version_hint_path).await?;
-
-        Ok(())
-    }
-
-    fn table_metadata_path(&self, table_path: &str, metadata_filename: &str) -> String {
-        format!("{table_path}/metadata/{metadata_filename}")
-    }
-
-    async fn rename(op: &Operator, src_path: &str, dest_path: &str) -> Result<()> {
-        let info = op.info();
-        if info.full_capability().rename {
-            Ok(op.rename(src_path, dest_path).await?)
-        } else {
-            op.copy(src_path, dest_path).await?;
-            op.delete(src_path).await?;
-            Ok(())
-        }
-    }
-
-    fn table_operator(&self, table_path: &str) -> Result<Operator> {
-        Operator::try_from(&self.config.op_args.sub_dir(table_path)?)
-    }
 }
+
 
 impl Namespace {
     fn to_path(&self) -> Result<String> {

--- a/icelake/src/table.rs
+++ b/icelake/src/table.rs
@@ -396,7 +396,7 @@ impl Table {
 mod tests {
     use std::env;
 
-    use crate::catalog::StorageCatalog;
+    use crate::catalog::IcebergStorageCatalog;
 
     use super::*;
 
@@ -404,7 +404,7 @@ mod tests {
     async fn test_table_version_hint() -> Result<()> {
         let path = format!("{}/../testdata/simple_table", env!("CARGO_MANIFEST_DIR"));
 
-        let table = StorageCatalog::load_table(&path).await?;
+        let table = IcebergStorageCatalog::load_table(&path).await?;
 
         let version_hint = table.current_table_version();
 
@@ -417,7 +417,7 @@ mod tests {
     async fn test_table_load() -> Result<()> {
         let path = format!("{}/../testdata/simple_table", env!("CARGO_MANIFEST_DIR"));
 
-        let table = StorageCatalog::load_table(&path).await?;
+        let table = IcebergStorageCatalog::load_table(&path).await?;
 
         let table_metadata = table.current_table_metadata();
         assert_eq!(table_metadata.format_version, types::TableFormatVersion::V1);
@@ -430,7 +430,7 @@ mod tests {
     async fn test_table_load_without_version_hint() -> Result<()> {
         let path = format!("{}/../testdata/no_hint_table", env!("CARGO_MANIFEST_DIR"));
 
-        let table = StorageCatalog::load_table(&path).await?;
+        let table = IcebergStorageCatalog::load_table(&path).await?;
 
         let table_metadata = table.current_table_metadata();
         assert_eq!(table_metadata.format_version, types::TableFormatVersion::V1);
@@ -447,7 +447,7 @@ mod tests {
     async fn test_table_current_data_files() -> Result<()> {
         let path = format!("{}/../testdata/simple_table", env!("CARGO_MANIFEST_DIR"));
 
-        let table = StorageCatalog::load_table(&path).await?;
+        let table = IcebergStorageCatalog::load_table(&path).await?;
 
         let data_files = table.current_data_files().await?;
         assert_eq!(data_files.len(), 3);


### PR DESCRIPTION
This PR adds a operator creator to allow users to reuse storage catalog without adapt to iceberg io config.

A new catalog called `IcebergStorageCatalog` has been added to make it more clear that it accepts iceberg's config.

---

We could make this part better in the future via opendal's own config.