### PR TITLE
feat: disable bloom fliter by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,15 +11,15 @@ resolver = "2"
 anyhow = "1"
 async-trait = "0.1"
 apache-avro = { version = "0.15", features = ["derive"] }
-arrow-array = { version = ">=46" }
-arrow-schema = { version = ">=46" }
-arrow-select = { version = ">=46" }
-arrow-row = { version = ">=46" }
-arrow-buffer = { version = ">=46" }
-arrow-arith = { version = ">=46" }
-arrow-csv = { version = ">=46" }
-arrow-cast = { version = ">=46" }
-arrow-ord = { version = ">=46" }
+arrow-array = { version = ">=48" }
+arrow-schema = { version = ">=48" }
+arrow-select = { version = ">=48" }
+arrow-row = { version = ">=48" }
+arrow-buffer = { version = ">=48" }
+arrow-arith = { version = ">=48" }
+arrow-csv = { version = ">=48" }
+arrow-cast = { version = ">=48" }
+arrow-ord = { version = ">=48" }
 bytes = "1"
 opendal = { version = ">=0.40", features = ["layers-prometheus"] }
 uuid = { version = "1", features = ["v4"] }

--- a/icelake/src/config.rs
+++ b/icelake/src/config.rs
@@ -274,7 +274,7 @@ impl Default for ParquetWriterConfig {
     fn default() -> Self {
         let parquet_writer_properties = WriterProperties::default();
         Self {
-            enable_bloom_filter: true,
+            enable_bloom_filter: false,
             created_by: None,
             compression: Compression::SNAPPY,
             max_row_group_size: parquet_writer_properties.max_row_group_size(),

--- a/icelake/tests/scan_test.rs
+++ b/icelake/tests/scan_test.rs
@@ -215,7 +215,7 @@ impl<F: FnMut(TableScanBuilder) -> TableScan> ScanTestCase<F> {
         .unwrap();
 
         let csv_reader = ReaderBuilder::new(schema.clone())
-            .has_header(false)
+            .with_header(false)
             .build(file)
             .unwrap();
 

--- a/icelake/tests/utils/test_generator.rs
+++ b/icelake/tests/utils/test_generator.rs
@@ -39,7 +39,7 @@ impl TestCase {
         let schema = Arc::new(Self::parse_schema(toml_content.table_schema));
 
         let csv_reader = ReaderBuilder::new(schema.clone())
-            .has_header(false)
+            .with_header(false)
             .build(toml_content.data.as_bytes())
             .unwrap();
         let write_data = csv_reader.map(|r| r.unwrap()).collect::<Vec<RecordBatch>>();


### PR DESCRIPTION
As in https://github.com/risingwavelabs/risingwave/issues/13048#issuecomment-1780572388, enable bloom fliter may cause huge memory cost. So let's disable by default.