### PR TITLE
refactor: refactor writer

### DIFF
--- a/.github/workflows/ci_typos.yml
+++ b/.github/workflows/ci_typos.yml
@@ -1,0 +1,30 @@
+name: Typos Check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+env:
+  RUST_BACKTRACE: 1
+
+jobs:
+  typos-check:
+    name: typos check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      FORCE_COLOR: 1
+    steps:
+      - uses: actions/checkout@v4
+      - run: curl -LsSf https://github.com/crate-ci/typos/releases/download/v1.14.8/typos-v1.14.8-x86_64-unknown-linux-musl.tar.gz | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+
+      - name: do typos check with typos-cli
+        run: typos icelake

--- a/icelake/src/catalog/io.rs
+++ b/icelake/src/catalog/io.rs
@@ -45,8 +45,6 @@ pub trait OperatorCreator: Send + Sync + 'static {
 pub struct IcebergTableIoArgs {
     scheme: Scheme,
     args: HashMap<String, String>,
-
-    op: Operator,
 }
 
 impl IcebergTableIoArgs {
@@ -117,12 +115,9 @@ impl IcebergTableIoArgsBuilder {
 
     /// Build arg.
     pub fn build(self) -> Result<IcebergTableIoArgs> {
-        let op = Operator::via_map(self.scheme, self.args.clone())?;
-
         Ok(IcebergTableIoArgs {
             scheme: self.scheme,
             args: self.args,
-            op,
         })
     }
 }

--- a/icelake/src/catalog/mod.rs
+++ b/icelake/src/catalog/mod.rs
@@ -1,6 +1,5 @@
 //! This module defines catalog api for icelake.
 
-#![allow(dead_code)]
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -123,7 +122,7 @@ pub trait Catalog: Send + Sync {
     }
 
     /// Update table.
-    async fn update_table(self: Arc<Self>, _udpate_table: &UpdateTable) -> Result<Table> {
+    async fn update_table(self: Arc<Self>, _update_table: &UpdateTable) -> Result<Table> {
         Err(Error::new(
             ErrorKind::IcebergFeatureUnsupported,
             format!("update_table is not supported by {}", self.name()),
@@ -131,9 +130,9 @@ pub trait Catalog: Send + Sync {
     }
 }
 
-/// Update table requirments
+/// Update table requirements
 #[derive(Debug, Clone, EnumDisplay)]
-pub enum UpdateRquirement {
+pub enum UpdateRequirement {
     /// Requirest table exists.
     AssertTableDoesNotExist,
     /// Requirest current table's uuid .
@@ -172,11 +171,11 @@ pub enum UpdateRquirement {
     },
 }
 
-impl UpdateRquirement {
+impl UpdateRequirement {
     fn check(&self, table_metadata: &TableMetadata) -> bool {
         match self {
-            UpdateRquirement::AssertTableDoesNotExist => false,
-            UpdateRquirement::AssertTableUUID(uuid) => {
+            UpdateRequirement::AssertTableDoesNotExist => false,
+            UpdateRequirement::AssertTableUUID(uuid) => {
                 table_metadata.table_uuid == uuid.to_string()
             }
             _ => todo!(),
@@ -207,12 +206,12 @@ pub enum MetadataUpdate {
     AddPartitionSpec {
         /// Spec id
         spec_id: i32,
-        /// Partiton fields
+        /// Partition fields
         fields: Vec<PartitionField>,
     },
-    /// Set default partiton spec.
-    SetDefaultPartitonSpec {
-        /// Partiton spec id
+    /// Set default partition spec.
+    SetDefaultPartitionSpec {
+        /// partition spec id
         spec_id: i32,
     },
     /// Add sort order.
@@ -220,7 +219,7 @@ pub enum MetadataUpdate {
         /// Sort order
         sort_order: SortOrder,
     },
-    /// Set defaut sort order
+    /// Set default sort order
     SetDefaultSortOrder {
         /// Sort order id
         sort_order_id: i32,
@@ -304,7 +303,7 @@ impl MetadataUpdate {
 /// Update table request.
 pub struct UpdateTable {
     table_name: TableIdentifier,
-    requirements: Vec<UpdateRquirement>,
+    requirements: Vec<UpdateRequirement>,
     updates: Vec<MetadataUpdate>,
 }
 
@@ -326,7 +325,7 @@ impl UpdateTableBuilder {
     /// Add requirements.
     pub fn add_requirements(
         &mut self,
-        requirements: impl IntoIterator<Item = UpdateRquirement>,
+        requirements: impl IntoIterator<Item = UpdateRequirement>,
     ) -> &mut Self {
         self.0.requirements.extend(requirements);
         self
@@ -369,7 +368,7 @@ pub struct BaseCatalogConfig {
 /// - [`CATALOG_TYPE`]: Type of catalog, must be one of `storage`, `rest`.
 /// - [`CATALOG_NAME`]: Name of catalog.
 ///
-/// ## Catalog specifig configuration.
+/// ## Catalog specific configuration.
 ///
 /// Catalog specific configurations are prefixed with `iceberg.catalog.<catalog name>`.
 /// For example, if catalog name is `demo`, then all catalog specific configuration keys must be prefixed with `iceberg.catalog.demo.`.:

--- a/icelake/src/catalog/mod.rs
+++ b/icelake/src/catalog/mod.rs
@@ -1,5 +1,6 @@
 //! This module defines catalog api for icelake.
 
+#![allow(dead_code)]
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 

--- a/icelake/src/catalog/prometheus.rs
+++ b/icelake/src/catalog/prometheus.rs
@@ -132,9 +132,9 @@ impl Catalog for PrometheusLayeredCatalog {
     }
 
     /// Update table.
-    async fn update_table(self: Arc<Self>, udpate_table: &UpdateTable) -> Result<Table> {
+    async fn update_table(self: Arc<Self>, update_table: &UpdateTable) -> Result<Table> {
         self.metrics.update_table_qps.inc();
         let _ = self.metrics.update_table_latency.start_timer();
-        self.inner.clone().update_table(udpate_table).await
+        self.inner.clone().update_table(update_table).await
     }
 }

--- a/icelake/src/catalog/prometheus.rs
+++ b/icelake/src/catalog/prometheus.rs
@@ -6,15 +6,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use prometheus::core::AtomicU64;
 use prometheus::core::GenericCounter;
-use prometheus::histogram_opts;
-use prometheus::opts;
-use prometheus::register_histogram_vec_with_registry;
-use prometheus::register_int_counter_vec_with_registry;
 use prometheus::Histogram;
-use prometheus::HistogramVec;
-use prometheus::IntCounterVec;
-use prometheus::Registry;
-use prometheus::DEFAULT_BUCKETS;
 
 use crate::types::PartitionSpec;
 use crate::types::Schema;
@@ -28,170 +20,26 @@ use super::CatalogLayer;
 use super::CatalogRef;
 use super::UpdateTable;
 
-const CATALOG_METRICS_LABEL_NAMES: &[&str] = &["context", "catalog"];
 #[derive(Clone)]
-pub(crate) struct CatalogMetricsDef {
-    load_table_qps: IntCounterVec,
-    load_table_latency: HistogramVec,
-
-    list_table_qps: IntCounterVec,
-    list_table_latency: HistogramVec,
-
-    update_table_qps: IntCounterVec,
-    update_table_latency: HistogramVec,
-}
-
-pub(crate) struct CatalogMetrics {
-    pub(crate) load_table_qps: GenericCounter<AtomicU64>,
-    pub(crate) load_table_latency: Histogram,
-    pub(crate) list_table_qps: GenericCounter<AtomicU64>,
-    pub(crate) list_table_latency: Histogram,
-    pub(crate) update_table_qps: GenericCounter<AtomicU64>,
-    pub(crate) update_table_latency: Histogram,
-}
-
-impl CatalogMetricsDef {
-    fn new(registry: &Registry) -> Self {
-        let load_table_qps = register_int_counter_vec_with_registry!(
-            opts!(
-                "iceberg_load_table_qps",
-                "Iceberg load table qps by desc and catallog name",
-            ),
-            CATALOG_METRICS_LABEL_NAMES,
-            registry,
-        )
-        .unwrap();
-
-        let load_table_latency = register_histogram_vec_with_registry!(
-            histogram_opts!(
-                "iceberg_load_table_latency",
-                "Iceberg load table latency by desc and catalog name",
-                DEFAULT_BUCKETS.to_vec(),
-            ),
-            CATALOG_METRICS_LABEL_NAMES,
-            registry,
-        )
-        .unwrap();
-
-        let list_table_qps = register_int_counter_vec_with_registry!(
-            opts!(
-                "iceberg_list_table_qps",
-                "Iceberg list table qps by desc and catalog name",
-            ),
-            CATALOG_METRICS_LABEL_NAMES,
-            registry,
-        )
-        .unwrap();
-
-        let list_table_latency = register_histogram_vec_with_registry!(
-            histogram_opts!(
-                "iceberg_list_table_latency",
-                "Iceberg list table latency by desc and catalog name",
-                DEFAULT_BUCKETS.to_vec(),
-            ),
-            CATALOG_METRICS_LABEL_NAMES,
-            registry,
-        )
-        .unwrap();
-
-        let update_table_qps = register_int_counter_vec_with_registry!(
-            opts!("iceberg_update_table_qps", "Iceberg update table qps",),
-            CATALOG_METRICS_LABEL_NAMES,
-            registry,
-        )
-        .unwrap();
-
-        let update_table_latency = register_histogram_vec_with_registry!(
-            histogram_opts!(
-                "iceberg_update_table_latency",
-                "Iceberg update table latency",
-                DEFAULT_BUCKETS.to_vec(),
-            ),
-            CATALOG_METRICS_LABEL_NAMES,
-            registry,
-        )
-        .unwrap();
-
-        Self {
-            load_table_qps,
-            load_table_latency,
-
-            list_table_qps,
-            list_table_latency,
-
-            update_table_qps,
-            update_table_latency,
-        }
-    }
+pub struct CatalogMetrics {
+    pub load_table_qps: GenericCounter<AtomicU64>,
+    pub load_table_latency: Histogram,
+    pub list_table_qps: GenericCounter<AtomicU64>,
+    pub list_table_latency: Histogram,
+    pub update_table_qps: GenericCounter<AtomicU64>,
+    pub update_table_latency: Histogram,
 }
 
 /// Iceberg prometheus layer.
 #[derive(Clone)]
 pub struct CatalogPrometheusLayer {
-    /// Field for identify current context.
-    ///
-    /// One of the motivation case is to prefix of metrics.
-    context_desc: String,
-    prometheus_registry: Registry,
-
-    name: String,
+    metrics: CatalogMetrics,
 }
 
 impl CatalogPrometheusLayer {
     /// Create iceberg context.
-    pub fn new(desc: impl ToString, prometheus_registry: Registry, name: impl ToString) -> Self {
-        Self {
-            context_desc: desc.to_string(),
-            name: name.to_string(),
-            prometheus_registry,
-        }
-    }
-
-    /// Description of current context.
-    pub fn desc(&self) -> &str {
-        self.context_desc.as_str()
-    }
-
-    /// Prometheus registry.
-    pub fn prometheus_registry(&self) -> &Registry {
-        &self.prometheus_registry
-    }
-
-    /// Catalog name
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-
-    fn metrics(&self) -> CatalogMetrics {
-        let def = CatalogMetricsDef::new(&self.prometheus_registry);
-
-        let label_values = [self.desc(), self.name()];
-        CatalogMetrics {
-            load_table_qps: def
-                .load_table_qps
-                .get_metric_with_label_values(&label_values)
-                .unwrap(),
-            load_table_latency: def
-                .load_table_latency
-                .get_metric_with_label_values(&label_values)
-                .unwrap(),
-            list_table_qps: def
-                .list_table_qps
-                .get_metric_with_label_values(&label_values)
-                .unwrap(),
-            list_table_latency: def
-                .list_table_latency
-                .get_metric_with_label_values(&label_values)
-                .unwrap(),
-            update_table_qps: def
-                .update_table_qps
-                .get_metric_with_label_values(&label_values)
-                .unwrap(),
-            update_table_latency: def
-                .update_table_latency
-                .get_metric_with_label_values(&label_values)
-                .unwrap(),
-        }
+    pub fn new(metrics: CatalogMetrics) -> Self {
+        Self { metrics }
     }
 }
 
@@ -201,7 +49,7 @@ impl CatalogLayer for CatalogPrometheusLayer {
     fn layer(&self, catalog: CatalogRef) -> Arc<Self::LayeredCatalog> {
         Arc::new(PrometheusLayeredCatalog {
             inner: catalog,
-            metrics: self.metrics(),
+            metrics: self.metrics.clone(),
         })
     }
 }

--- a/icelake/src/catalog/rest.rs
+++ b/icelake/src/catalog/rest.rs
@@ -77,7 +77,7 @@ impl Catalog for RestCatalog {
                 |status| match status {
                     StatusCode::NOT_FOUND => Some(Error::new(
                         ErrorKind::IcebergDataInvalid,
-                        format!("Talbe {table_name} not found!"),
+                        format!("Table {table_name} not found!"),
                     )),
                     _ => None,
                 },
@@ -195,7 +195,7 @@ impl RestCatalog {
                     Err(Error::new(
                         ErrorKind::Unexpected,
                         format!(
-                            "Faile to execute http request, status code: {other}, message: {text}"
+                            "Fail to execute http request, status code: {other}, message: {text}"
                         ),
                     ))
                 }
@@ -326,7 +326,7 @@ mod _models {
     use serde::{Deserialize, Serialize};
 
     use crate::{
-        catalog::{self, MetadataUpdate, UpdateRquirement},
+        catalog::{self, MetadataUpdate, UpdateRequirement},
         table,
         types::{SnapshotSerDe, TableMetadataSerDe},
         Error,
@@ -423,10 +423,10 @@ mod _models {
         pub(super) default_sort_order_id: Option<i32>,
     }
 
-    impl From<&UpdateRquirement> for TableRequirement {
-        fn from(value: &UpdateRquirement) -> Self {
+    impl From<&UpdateRequirement> for TableRequirement {
+        fn from(value: &UpdateRequirement) -> Self {
             match value {
-                UpdateRquirement::AssertTableDoesNotExist => Self {
+                UpdateRequirement::AssertTableDoesNotExist => Self {
                     typ: "assert-create".to_string(),
                     r#ref: None,
                     uuid: None,
@@ -437,7 +437,7 @@ mod _models {
                     default_spec_id: None,
                     default_sort_order_id: None,
                 },
-                UpdateRquirement::AssertTableUUID(uuid) => Self {
+                UpdateRequirement::AssertTableUUID(uuid) => Self {
                     typ: "assert-table-uuid".to_string(),
                     r#ref: None,
                     uuid: Some(uuid.to_string()),
@@ -448,7 +448,7 @@ mod _models {
                     default_spec_id: None,
                     default_sort_order_id: None,
                 },
-                UpdateRquirement::AssertRefSnapshotID { name, snapshot_id } => Self {
+                UpdateRequirement::AssertRefSnapshotID { name, snapshot_id } => Self {
                     typ: "assert-ref-snapshot-id".to_string(),
                     r#ref: Some(name.clone()),
                     uuid: None,
@@ -459,7 +459,7 @@ mod _models {
                     default_spec_id: None,
                     default_sort_order_id: None,
                 },
-                UpdateRquirement::AssertLastAssignedFieldId {
+                UpdateRequirement::AssertLastAssignedFieldId {
                     last_assigned_field_id,
                 } => Self {
                     typ: "assert-last-assigned-field-id".to_string(),
@@ -472,7 +472,7 @@ mod _models {
                     default_spec_id: None,
                     default_sort_order_id: None,
                 },
-                UpdateRquirement::AssertCurrentSchemaID { schema_id } => Self {
+                UpdateRequirement::AssertCurrentSchemaID { schema_id } => Self {
                     typ: "assert-current-schema-id".to_string(),
                     r#ref: None,
                     uuid: None,
@@ -483,7 +483,7 @@ mod _models {
                     default_spec_id: None,
                     default_sort_order_id: None,
                 },
-                UpdateRquirement::AssertLastAssignedPartitionId {
+                UpdateRequirement::AssertLastAssignedPartitionId {
                     last_assigned_partition_id,
                 } => Self {
                     typ: "assert-last-assigned-partition-id".to_string(),
@@ -496,7 +496,7 @@ mod _models {
                     default_spec_id: None,
                     default_sort_order_id: None,
                 },
-                UpdateRquirement::AssertDefaultSpecID { spec_id } => Self {
+                UpdateRequirement::AssertDefaultSpecID { spec_id } => Self {
                     typ: "assert-default-spec-id".to_string(),
                     r#ref: None,
                     uuid: None,
@@ -507,7 +507,7 @@ mod _models {
                     default_spec_id: Some(*spec_id),
                     default_sort_order_id: None,
                 },
-                UpdateRquirement::AssertDefaultSortOrderID { sort_order_id } => Self {
+                UpdateRequirement::AssertDefaultSortOrderID { sort_order_id } => Self {
                     typ: "assert-default-sort-order-id".to_string(),
                     r#ref: None,
                     uuid: None,

--- a/icelake/src/catalog/storage.rs
+++ b/icelake/src/catalog/storage.rs
@@ -23,16 +23,8 @@ use super::{
 use crate::catalog::{OperatorCreator, CATALOG_CONFIG_PREFIX};
 use crate::error::Result;
 
-/// Configuration for storage config.
-pub struct StorageCatalogConfig<O: OperatorCreator> {
-    warehouse: String,
-    base_catalog_config: BaseCatalogConfig,
-    op_args: O,
-}
-
 /// File system catalog.
 pub struct StorageCatalog<O: OperatorCreator> {
-    warehouse: String,
     catalog_config: BaseCatalogConfig,
 
     operator_creator: O,
@@ -40,9 +32,8 @@ pub struct StorageCatalog<O: OperatorCreator> {
 
 impl<O: OperatorCreator> StorageCatalog<O> {
     /// Create a new storage catalog with given warehouse and operator creator.
-    pub fn new(warehouse: &str, operator_creator: O) -> Self {
+    pub fn new(operator_creator: O) -> Self {
         StorageCatalog {
-            warehouse: warehouse.to_string(),
             catalog_config: BaseCatalogConfig {
                 name: "storage".to_string(),
                 ..Default::default()
@@ -52,13 +43,8 @@ impl<O: OperatorCreator> StorageCatalog<O> {
     }
 
     /// Create a new storage catalog with given catalog config.
-    pub fn with_catalog_config(
-        warehouse: &str,
-        operator_creator: O,
-        catalog_config: BaseCatalogConfig,
-    ) -> Self {
+    pub fn with_catalog_config(operator_creator: O, catalog_config: BaseCatalogConfig) -> Self {
         StorageCatalog {
-            warehouse: warehouse.to_string(),
             catalog_config,
             operator_creator,
         }
@@ -132,7 +118,7 @@ impl<O: OperatorCreator> StorageCatalog<O> {
     ///
     /// The returned paths are sorted by name.
     ///
-    /// TODO: we can imporve this by only fetch the latest metadata.
+    /// TODO: we can improve this by only fetch the latest metadata.
     ///
     /// `table_path`: relative path of table dir under warehouse root.
     async fn list_table_metadata_paths(&self, table_path: &str) -> Result<Vec<String>> {
@@ -241,10 +227,6 @@ impl<O: OperatorCreator> StorageCatalog<O> {
         .await?;
 
         Ok(())
-    }
-
-    fn table_metadata_path(&self, table_path: &str, metadata_filename: &str) -> String {
-        format!("{table_path}/metadata/{metadata_filename}")
     }
 
     async fn rename(op: &Operator, src_path: &str, dest_path: &str) -> Result<()> {
@@ -391,11 +373,7 @@ impl IcebergStorageCatalog {
             .with_args(base_config.table_io_configs.iter())
             .build()?;
 
-        Ok(StorageCatalog::with_catalog_config(
-            warehouse,
-            op,
-            base_config,
-        ))
+        Ok(StorageCatalog::with_catalog_config(op, base_config))
     }
 
     /// Load table from path.

--- a/icelake/src/error.rs
+++ b/icelake/src/error.rs
@@ -209,7 +209,7 @@ impl From<parquet::errors::ParquetError> for Error {
 
 impl From<std::time::SystemTimeError> for Error {
     fn from(v: std::time::SystemTimeError) -> Self {
-        Self::new(ErrorKind::Unexpected, "handling system time errror").set_source(v)
+        Self::new(ErrorKind::Unexpected, "handling system time error").set_source(v)
     }
 }
 

--- a/icelake/src/io/append_only_writer.rs
+++ b/icelake/src/io/append_only_writer.rs
@@ -2,7 +2,6 @@
 //! table writer used directly by the compute engine.
 use super::file_writer::DataFileWriter;
 use super::DefaultFileAppender;
-use super::FileAppender;
 use super::FileAppenderBuilder;
 use super::FileAppenderLayer;
 use crate::error::Result;

--- a/icelake/src/io/append_only_writer.rs
+++ b/icelake/src/io/append_only_writer.rs
@@ -1,12 +1,10 @@
 //! task_writer module provide a task writer for writing data in a table.
 //! table writer used directly by the compute engine.
 use super::file_writer::DataFileWriter;
-use super::location_generator;
 use super::DefaultFileAppender;
 use super::FileAppender;
 use super::FileAppenderBuilder;
 use super::FileAppenderLayer;
-use crate::config::TableConfigRef;
 use crate::error::Result;
 use crate::io::location_generator::FileLocationGenerator;
 use crate::types::Any;
@@ -16,7 +14,6 @@ use crate::types::PartitionSplitter;
 use crate::types::{DataFile, TableMetadata};
 use arrow_array::RecordBatch;
 use arrow_schema::SchemaRef as ArrowSchemaRef;
-use opendal::Operator;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -29,23 +26,19 @@ use std::sync::Arc;
 /// If the table metadata has no partition spec, it will create a unpartitioned
 /// task writer. The unpartitioned task writer will write all data using a single
 /// data file writer.
-pub enum TaskWriter<L: FileAppenderLayer<DefaultFileAppender>> {
+pub enum AppendOnlyWriter<L: FileAppenderLayer<DefaultFileAppender>> {
     /// Unpartitioned task writer
-    Unpartitioned(UnpartitionedWriter<L::R>),
+    Unpartitioned(UnpartitionedAppendOnlyWriter<L::R>),
     /// Partitioned task writer
-    Partitioned(PartitionedWriter<L>),
+    Partitioned(PartitionedAppendOnlyWriter<L>),
 }
 
-impl<L: FileAppenderLayer<DefaultFileAppender>> TaskWriter<L> {
+impl<L: FileAppenderLayer<DefaultFileAppender>> AppendOnlyWriter<L> {
     /// Create a new `TaskWriter`.
     pub async fn try_new(
         table_metadata: TableMetadata,
-        operator: Operator,
-        partition_id: usize,
-        task_id: usize,
-        suffix: Option<String>,
-        table_config: TableConfigRef,
         file_appender_factory: FileAppenderBuilder<L>,
+        location_generator: Arc<FileLocationGenerator>,
     ) -> Result<Self> {
         let current_schema = table_metadata.current_schema()?;
         let current_partition_spec = table_metadata.current_partition_spec()?;
@@ -57,16 +50,11 @@ impl<L: FileAppenderLayer<DefaultFileAppender>> TaskWriter<L> {
             )
         })?);
 
-        let location_generator = location_generator::FileLocationGenerator::try_new_for_data_file(
-            &table_metadata,
-            partition_id,
-            task_id,
-            suffix,
-        )?;
-
         if current_partition_spec.is_unpartitioned() {
-            Ok(Self::Unpartitioned(UnpartitionedWriter::try_new(
-                file_appender_factory.build(arrow_schema).await?,
+            Ok(Self::Unpartitioned(UnpartitionedAppendOnlyWriter::try_new(
+                file_appender_factory
+                    .build(arrow_schema, location_generator)
+                    .await?,
             )?))
         } else {
             let partition_type = Any::Struct(
@@ -74,14 +62,11 @@ impl<L: FileAppenderLayer<DefaultFileAppender>> TaskWriter<L> {
                     .partition_type(current_schema)?
                     .into(),
             );
-            Ok(Self::Partitioned(PartitionedWriter::try_new(
+            Ok(Self::Partitioned(PartitionedAppendOnlyWriter::try_new(
                 arrow_schema,
-                table_metadata.location.clone(),
                 location_generator,
                 current_partition_spec,
                 partition_type,
-                operator,
-                table_config,
                 file_appender_factory,
             )?))
         }
@@ -90,26 +75,26 @@ impl<L: FileAppenderLayer<DefaultFileAppender>> TaskWriter<L> {
     /// Write a record batch.
     pub async fn write(&mut self, batch: &RecordBatch) -> Result<()> {
         match self {
-            TaskWriter::Unpartitioned(writer) => writer.write(batch).await,
-            TaskWriter::Partitioned(writer) => writer.write(batch).await,
+            AppendOnlyWriter::Unpartitioned(writer) => writer.write(batch).await,
+            AppendOnlyWriter::Partitioned(writer) => writer.write(batch).await,
         }
     }
 
     /// Close the writer and return the data files.
     pub async fn close(self) -> Result<Vec<DataFile>> {
         match self {
-            TaskWriter::Unpartitioned(writer) => writer.close().await,
-            TaskWriter::Partitioned(writer) => writer.close().await,
+            AppendOnlyWriter::Unpartitioned(writer) => writer.close().await,
+            AppendOnlyWriter::Partitioned(writer) => writer.close().await,
         }
     }
 }
 
-/// Unpartitioned task writer
-pub struct UnpartitionedWriter<F: FileAppender> {
+/// Unpartitioned append only writer
+pub struct UnpartitionedAppendOnlyWriter<F: FileAppender> {
     data_file_writer: DataFileWriter<F>,
 }
 
-impl<F: FileAppender> UnpartitionedWriter<F> {
+impl<F: FileAppender> UnpartitionedAppendOnlyWriter<F> {
     /// Create a new `TaskWriter`.
     pub fn try_new(writer: F) -> Result<Self> {
         Ok(Self {
@@ -140,45 +125,34 @@ impl<F: FileAppender> UnpartitionedWriter<F> {
     }
 }
 
-/// Partition task writer
-pub struct PartitionedWriter<L: FileAppenderLayer<DefaultFileAppender>> {
-    operator: Operator,
-    table_location: String,
+/// Partition append only writer
+pub struct PartitionedAppendOnlyWriter<L: FileAppenderLayer<DefaultFileAppender>> {
     location_generator: Arc<FileLocationGenerator>,
-    table_config: TableConfigRef,
     schema: ArrowSchemaRef,
-    partition_type: Any,
 
     writers: HashMap<PartitionKey, DataFileWriter<L::R>>,
     partition_splitter: PartitionSplitter,
     file_appender_factory: FileAppenderBuilder<L>,
 }
 
-impl<L: FileAppenderLayer<DefaultFileAppender>> PartitionedWriter<L> {
+impl<L: FileAppenderLayer<DefaultFileAppender>> PartitionedAppendOnlyWriter<L> {
     /// Create a new `PartitionedWriter`.
     #[allow(clippy::too_many_arguments)]
     pub fn try_new(
         schema: ArrowSchemaRef,
-        table_location: String,
-        location_generator: FileLocationGenerator,
+        location_generator: Arc<FileLocationGenerator>,
         partition_spec: &PartitionSpec,
         partition_type: Any,
-        operator: Operator,
-        table_config: TableConfigRef,
         file_appender_factory: FileAppenderBuilder<L>,
     ) -> Result<Self> {
         Ok(Self {
-            operator,
-            table_location,
-            location_generator: location_generator.into(),
-            table_config,
+            location_generator,
             writers: HashMap::new(),
             partition_splitter: PartitionSplitter::try_new(
                 partition_spec,
                 &schema,
-                partition_type.clone(),
+                partition_type,
             )?,
-            partition_type,
             schema,
             file_appender_factory,
         })
@@ -198,7 +172,7 @@ impl<L: FileAppenderLayer<DefaultFileAppender>> PartitionedWriter<L> {
                     writer
                         .insert(DataFileWriter::try_new(
                             self.file_appender_factory
-                                .build(self.schema.clone())
+                                .build(self.schema.clone(), self.location_generator.clone())
                                 .await?,
                         )?)
                         .write(batch)

--- a/icelake/src/io/file_writer/data_file_writer.rs
+++ b/icelake/src/io/file_writer/data_file_writer.rs
@@ -98,10 +98,9 @@ mod test {
             new_file_appender_builder(
                 op.clone(),
                 "/tmp/table".to_string(),
-                location_generator.into(),
                 Arc::new(TableConfig::default()),
             )
-            .build(to_write.schema())
+            .build(to_write.schema(), location_generator.into())
             .await?,
         )?;
 

--- a/icelake/src/io/file_writer/data_file_writer.rs
+++ b/icelake/src/io/file_writer/data_file_writer.rs
@@ -9,7 +9,7 @@ use arrow_array::RecordBatch;
 /// When complete, it will return a list of `DataFile`.
 ///
 /// # NOTE
-/// This writer will not gurantee the writen data is within one spec/partition. It is the caller's responsibility to make sure the data is within one spec/partition.
+/// This writer will not guarantee the written data is within one spec/partition. It is the caller's responsibility to make sure the data is within one spec/partition.
 pub struct DataFileWriter<F: FileAppender> {
     inner_writer: F,
 }

--- a/icelake/src/io/file_writer/equality_delete_writer.rs
+++ b/icelake/src/io/file_writer/equality_delete_writer.rs
@@ -2,7 +2,10 @@
 use std::sync::Arc;
 
 use crate::{
-    io::{DefaultFileAppender, FileAppender, FileAppenderBuilder, FileAppenderLayer},
+    io::{
+        location_generator, DefaultFileAppender, FileAppender, FileAppenderBuilder,
+        FileAppenderLayer,
+    },
     types::{DataFileBuilder, COLUMN_ID_META_KEY},
     Error, ErrorKind, Result,
 };
@@ -21,6 +24,7 @@ pub struct EqualityDeleteWriter<F: FileAppender> {
 pub async fn new_eq_delete_writer<L: FileAppenderLayer<DefaultFileAppender>>(
     arrow_schema: SchemaRef,
     equality_ids: Vec<usize>,
+    location_generator: Arc<location_generator::FileLocationGenerator>,
     factory: &FileAppenderBuilder<L>,
 ) -> Result<EqualityDeleteWriter<L::R>> {
     let mut col_id_idx = vec![];
@@ -51,7 +55,7 @@ pub async fn new_eq_delete_writer<L: FileAppenderLayer<DefaultFileAppender>>(
     })?);
 
     Ok(EqualityDeleteWriter {
-        inner_writer: factory.build(delete_schema).await?,
+        inner_writer: factory.build(delete_schema, location_generator).await?,
         equality_ids,
         col_id_idx,
     })

--- a/icelake/src/io/file_writer/equality_delta_writer.rs
+++ b/icelake/src/io/file_writer/equality_delta_writer.rs
@@ -38,7 +38,7 @@ pub struct DeltaWriterResult {
 
 /// `EqualityDeltaWriter` is same as: https://github.com/apache/iceberg/blob/2e1ec5fde9e6fecfbc0883465a585a1dacb58c05/core/src/main/java/org/apache/iceberg/io/BaseTaskWriter.java#L108
 ///
-/// EqualityDeltaWriter will gurantee that there is only one row with the unique columns value written. When
+/// EqualityDeltaWriter will guarantee that there is only one row with the unique columns value written. When
 /// insert a row with the same unique columns value, it will delete the previous row.
 ///
 /// NOTE:
@@ -191,7 +191,7 @@ impl<L: FileAppenderLayer<DefaultFileAppender>> EqualityDeltaWriter<L> {
     }
 
     /// Write the batch.
-    /// 1. If a row wtih the same unique column is not written, then insert it.
+    /// 1. If a row with the same unique column is not written, then insert it.
     /// 2. If a row with the same unique column is written, then delete the previous row and insert the new row.
     pub async fn write(&mut self, batch: RecordBatch) -> Result<()> {
         let rows = self.extract_unique_column(&batch)?;

--- a/icelake/src/io/file_writer/position_delete_writer.rs
+++ b/icelake/src/io/file_writer/position_delete_writer.rs
@@ -124,7 +124,7 @@ fn arrow_schema_of(row_type: Option<Arc<Struct>>) -> Result<SchemaRef> {
 /// - Sorting by pos allows filtering rows while scanning, to avoid keeping deletes in memory.
 /// - They're belong to partition.
 ///
-/// But PositionDeleteWriter will not gurantee and check above. It is the caller's responsibility to gurantee them.
+/// But PositionDeleteWriter will not guarantee and check above. It is the caller's responsibility to guarantee them.
 pub struct PositionDeleteWriter<F: FileAppender> {
     schema: SchemaRef,
     inner_writer: F,
@@ -175,7 +175,7 @@ impl<F: FileAppender> PositionDeleteWriter<F> {
             .close()
             .await?
             .into_iter()
-            .map(|builder| builder.with_content(crate::types::DataContentType::PostionDeletes))
+            .map(|builder| builder.with_content(crate::types::DataContentType::PositionDeletes))
             .collect())
     }
 }

--- a/icelake/src/io/location_generator.rs
+++ b/icelake/src/io/location_generator.rs
@@ -30,26 +30,26 @@ pub struct FileLocationGenerator {
 impl FileLocationGenerator {
     /// Create a file location generator for data file.
     pub fn try_new_for_data_file(
-        table_metatdata: &TableMetadata,
+        table_metadata: &TableMetadata,
         partition_id: usize,
         task_id: usize,
         suffix: Option<String>,
     ) -> Result<Self> {
-        Self::try_new(table_metatdata, partition_id, task_id, suffix, false)
+        Self::try_new(table_metadata, partition_id, task_id, suffix, false)
     }
 
     /// Create a file location generator for delete file.
     pub fn try_new_for_delete_file(
-        table_metatdata: &TableMetadata,
+        table_metadata: &TableMetadata,
         partition_id: usize,
         task_id: usize,
         suffix: Option<String>,
     ) -> Result<Self> {
-        Self::try_new(table_metatdata, partition_id, task_id, suffix, true)
+        Self::try_new(table_metadata, partition_id, task_id, suffix, true)
     }
 
     fn try_new(
-        table_metatdata: &TableMetadata,
+        table_metadata: &TableMetadata,
         partition_id: usize,
         task_id: usize,
         suffix: Option<String>,
@@ -58,7 +58,7 @@ impl FileLocationGenerator {
         let operation_id = Uuid::new_v4().to_string();
 
         let file_format = DataFileFormat::from_str(
-            &table_metatdata
+            &table_metadata
                 .properties
                 .as_ref()
                 .and_then(|prop| prop.get(DEFAULT_FILE_FORMAT))
@@ -68,8 +68,8 @@ impl FileLocationGenerator {
         .unwrap_or(DataFileFormat::Parquet);
 
         let data_rel_location = {
-            let base_location = &table_metatdata.location;
-            let data_location = table_metatdata.properties.as_ref().and_then(|prop| {
+            let base_location = &table_metadata.location;
+            let data_location = table_metadata.properties.as_ref().and_then(|prop| {
                 prop.get(WRITE_DATA_LOCATION)
                     .or(prop.get(WRITE_FOLDER_STORAGE_LOCATION))
                     .cloned()

--- a/icelake/src/io/mod.rs
+++ b/icelake/src/io/mod.rs
@@ -1,11 +1,12 @@
 //! io module provides the ability to read and write data from various
 //! sources.
+#![warn(dead_code)]
 
+pub mod append_only_writer;
 mod appender;
 pub mod file_writer;
 pub mod location_generator;
 pub mod parquet;
-pub mod task_writer;
 pub mod writer_builder;
 pub use appender::*;
 mod scan;

--- a/icelake/src/io/parquet/write.rs
+++ b/icelake/src/io/parquet/write.rs
@@ -81,7 +81,7 @@ pub struct ParquetWriter {
 impl ParquetWriter {
     /// Write data into the file.
     ///
-    /// Note: It will not guarantee to take effect imediately.
+    /// Note: It will not guarantee to take effect immediately.
     pub async fn write(&mut self, data: &RecordBatch) -> Result<()> {
         self.writer.write(data).await?;
         Ok(())

--- a/icelake/src/lib.rs
+++ b/icelake/src/lib.rs
@@ -3,7 +3,6 @@
 
 // Make sure all our public APIs have docs.
 // #![deny(missing_docs)]
-// #![allow(dead_code)]
 
 mod table;
 pub use table::*;

--- a/icelake/src/lib.rs
+++ b/icelake/src/lib.rs
@@ -3,7 +3,7 @@
 
 // Make sure all our public APIs have docs.
 // #![deny(missing_docs)]
-#![allow(dead_code)]
+// #![allow(dead_code)]
 
 mod table;
 pub use table::*;

--- a/icelake/src/types/mod.rs
+++ b/icelake/src/types/mod.rs
@@ -1,8 +1,5 @@
 //! Types will provide the definition of iceberg in-memory data types and
 //! functions to parse from on-disk files.
-
-#![allow(dead_code)]
-
 mod in_memory;
 pub use in_memory::*;
 

--- a/icelake/src/types/mod.rs
+++ b/icelake/src/types/mod.rs
@@ -1,6 +1,8 @@
 //! Types will provide the definition of iceberg in-memory data types and
 //! functions to parse from on-disk files.
 
+#![allow(dead_code)]
+
 mod in_memory;
 pub use in_memory::*;
 

--- a/icelake/src/types/on_disk/partition_spec.rs
+++ b/icelake/src/types/on_disk/partition_spec.rs
@@ -10,12 +10,6 @@ pub fn parse_partition_spec(bs: &[u8]) -> Result<types::PartitionSpec> {
     t.try_into()
 }
 
-/// Serialize partition spec to json bytes.
-pub fn serialize_partition_spec(spec: &types::PartitionSpec) -> Result<String> {
-    let t = PartitionSpec::try_from(spec)?;
-    Ok(serde_json::to_string(&t)?)
-}
-
 pub fn serialize_partition_spec_fields(spec: &types::PartitionSpec) -> Result<String> {
     let t = PartitionSpec::try_from(spec)?;
     Ok(serde_json::to_string(&t.fields)?)
@@ -110,7 +104,9 @@ mod tests {
         let parsed = parse_partition_spec(json.as_bytes()).unwrap();
         assert_eq!(expected_partition_spec, parsed);
 
-        let serialized_json = serialize_partition_spec(&expected_partition_spec).unwrap();
+        let serialized_json =
+            serde_json::to_string(&PartitionSpec::try_from(&expected_partition_spec).unwrap())
+                .unwrap();
         let parsed = parse_partition_spec(serialized_json.as_bytes()).unwrap();
         assert_eq!(expected_partition_spec, parsed);
 

--- a/icelake/src/types/on_disk/value.rs
+++ b/icelake/src/types/on_disk/value.rs
@@ -490,6 +490,7 @@ impl From<StructValue> for Value {
     }
 }
 
+#[cfg(test)]
 mod test {
     use std::sync::Arc;
 

--- a/icelake/src/types/partition_splitter.rs
+++ b/icelake/src/types/partition_splitter.rs
@@ -10,7 +10,7 @@ use arrow_row::{OwnedRow, RowConverter, SortField};
 use arrow_schema::{DataType, FieldRef, Fields, SchemaRef};
 use arrow_select::filter::filter_record_batch;
 
-/// `PartitionSplitter` is used to splite a given record according partition value.
+/// `PartitionSplitter` is used to split a given record according partition value.
 pub struct PartitionSplitter {
     field_infos: Vec<PartitionFieldComputeInfo>,
     partition_type: Any,
@@ -217,7 +217,7 @@ impl PartitionSplitter {
 
     /// Convert the `PartitionKey` to `PartitionValue`
     ///
-    /// The reason we seperate them is to save memmory cost, when in write process, we only need to
+    /// The reason we separate them is to save memory cost, when in write process, we only need to
     /// keep the `PartitionKey`. It's effiect to used in Hash. When write complete, we can use it to convert `PartitionKey` to
     /// `PartitionValue` to store it in `DataFile`.
     pub fn convert_key_to_value(&self, key: PartitionKey) -> Result<StructValue> {

--- a/icelake/src/types/to_avro.rs
+++ b/icelake/src/types/to_avro.rs
@@ -93,7 +93,7 @@ impl<'a> TryFrom<&'a Field> for AvroRecordField {
 /// this name is "r+ field_id", so we wrap Any with field_id to deal with this case.
 struct AnyWithFieldId<'a, 'b> {
     any: &'a Any,
-    /// We need to guaranteed that there is only one record use thi field_id. Otherwise there will
+    /// We need to guaranteed that there is only one record use this field_id. Otherwise there will
     /// be dulplicate name in AvroSchema. So we use Option to make sure that there is only one
     /// record take it.
     ///

--- a/icelake/tests/delta_test.rs
+++ b/icelake/tests/delta_test.rs
@@ -416,6 +416,6 @@ fn main() {
         }
     }
 
-    // Run all tests and exit the application appropriatly.
+    // Run all tests and exit the application appropriately.
     libtest_mimic::run(&args, tests).exit();
 }

--- a/icelake/tests/insert_compact_test.rs
+++ b/icelake/tests/insert_compact_test.rs
@@ -266,6 +266,6 @@ fn main() {
         }
     }
 
-    // Run all tests and exit the application appropriatly.
+    // Run all tests and exit the application appropriately.
     libtest_mimic::run(&args, tests).exit();
 }

--- a/icelake/tests/insert_compact_test.rs
+++ b/icelake/tests/insert_compact_test.rs
@@ -165,7 +165,7 @@ impl TestFixture {
                 .writer_builder()
                 .await
                 .unwrap()
-                .build_task_writer()
+                .build_append_only_writer()
                 .await
                 .unwrap();
 

--- a/icelake/tests/insert_tests.rs
+++ b/icelake/tests/insert_tests.rs
@@ -248,6 +248,6 @@ fn main() {
         }
     }
 
-    // Run all tests and exit the application appropriatly.
+    // Run all tests and exit the application appropriately.
     libtest_mimic::run(&args, tests).exit();
 }

--- a/icelake/tests/insert_tests.rs
+++ b/icelake/tests/insert_tests.rs
@@ -160,7 +160,7 @@ impl TestFixture {
             .writer_builder()
             .await
             .unwrap()
-            .build_task_writer()
+            .build_append_only_writer()
             .await
             .unwrap();
 

--- a/icelake/tests/utils/test_generator.rs
+++ b/icelake/tests/utils/test_generator.rs
@@ -19,7 +19,7 @@ pub struct TestCase {
 }
 
 #[derive(Deserialize, Debug)]
-struct TomlConent {
+struct TomlContent {
     pub schema_name: String,
     pub table_name: String,
     pub create_table_sql: String,
@@ -33,7 +33,7 @@ impl TestCase {
     pub fn parse<R: Read>(mut buf: R) -> Self {
         let mut content = String::new();
         buf.read_to_string(&mut content).unwrap();
-        let toml_content: TomlConent = toml::from_str(&content).unwrap();
+        let toml_content: TomlContent = toml::from_str(&content).unwrap();
 
         // Parse write data
         let schema = Arc::new(Self::parse_schema(toml_content.table_schema));


### PR DESCRIPTION
This PR
1. clear dead code
2. rename task writer to append only writer
3. separate location generator out to append builder

I find `#[allow(dead_code)] in lib will let us miss lots of dead code in the whole codebase. So I moved it to the type crate and catalog crate. 