### PR TITLE
fix convert from iceberg type to arrow type

### DIFF
--- a/icelake/src/types/arrow/to_arrow.rs
+++ b/icelake/src/types/arrow/to_arrow.rs
@@ -114,7 +114,7 @@ impl TryFrom<types::Primitive> for ArrowDataType {
                 Ok(ArrowDataType::Decimal128(precision, scale as i8))
             }
             types::Primitive::Date => Ok(ArrowDataType::Date32),
-            types::Primitive::Time => Ok(ArrowDataType::Time32(TimeUnit::Microsecond)),
+            types::Primitive::Time => Ok(ArrowDataType::Time64(TimeUnit::Microsecond)),
             types::Primitive::Timestamp => {
                 Ok(ArrowDataType::Timestamp(TimeUnit::Microsecond, None))
             }


### PR DESCRIPTION
iceberg `time` type has microsecond precision, the corresponding arrow type should be [`Time64MicrosecondType`](https://docs.rs/arrow/48.0.0/arrow/datatypes/struct.Time64MicrosecondType.html) whose [`DataType`](https://docs.rs/arrow/48.0.0/arrow/datatypes/enum.DataType.html#) is `DataType::Time64(TimeUnit::Microsecond)`