### PR TITLE
refactor: separate out column extractor of partition splitter

### DIFF
--- a/icelake/src/io/append_only_writer.rs
+++ b/icelake/src/io/append_only_writer.rs
@@ -7,7 +7,7 @@ use super::FileAppenderLayer;
 use crate::error::Result;
 use crate::io::location_generator::FileLocationGenerator;
 use crate::types::Any;
-use crate::types::ColumnExtractor;
+use crate::types::FieldProjector;
 use crate::types::PartitionKey;
 use crate::types::PartitionSplitter;
 use crate::types::{DataFile, TableMetadata};
@@ -61,7 +61,7 @@ impl<L: FileAppenderLayer<DefaultFileAppender>> AppendOnlyWriter<L> {
                 .iter()
                 .map(|field| field.source_column_id as usize)
                 .collect_vec();
-            let (col_extractor, _) = ColumnExtractor::new(&arrow_schema, &column_ids)?;
+            let (col_extractor, _) = FieldProjector::new(&arrow_schema, &column_ids)?;
             let partition_splitter = PartitionSplitter::try_new(
                 col_extractor,
                 current_partition_spec,

--- a/icelake/src/io/file_writer/equality_delta_writer.rs
+++ b/icelake/src/io/file_writer/equality_delta_writer.rs
@@ -4,9 +4,9 @@ use crate::io::location_generator::FileLocationGenerator;
 use crate::io::DefaultFileAppender;
 use crate::io::FileAppenderBuilder;
 use crate::io::FileAppenderLayer;
+use crate::types::ColumnExtractor;
 use crate::types::DataFile;
 use crate::types::StructValue;
-use crate::types::COLUMN_ID_META_KEY;
 use crate::{Error, ErrorKind, Result};
 use arrow_array::builder::BooleanBuilder;
 use arrow_array::RecordBatch;
@@ -48,7 +48,7 @@ pub struct EqualityDeltaWriter<L: FileAppenderLayer<DefaultFileAppender>> {
     eq_delete_writer: EqualityDeleteWriter<L::R>,
     inserted_rows: HashMap<OwnedRow, PathOffset>,
     row_converter: RowConverter,
-    unique_column_idx: Vec<usize>,
+    col_extractor: ColumnExtractor,
 }
 
 pub struct EqDeltaWriterMetrics {
@@ -67,43 +67,10 @@ impl<L: FileAppenderLayer<DefaultFileAppender>> EqualityDeltaWriter<L> {
         data_location_generator: Arc<FileLocationGenerator>,
         delete_location_generator: Arc<FileLocationGenerator>,
     ) -> Result<Self> {
-        // Convert column id into corresponding index.
-        let mut unique_column_idx = Vec::with_capacity(unique_column_ids.len());
-        for &id in unique_column_ids.iter() {
-            let res = arrow_schema
-                .fields
-                .iter()
-                .enumerate()
-                .find(|(_, f)| {
-                    f.metadata()
-                        .get(COLUMN_ID_META_KEY)
-                        .unwrap()
-                        .parse::<usize>()
-                        .unwrap()
-                        == id
-                })
-                .ok_or_else(|| {
-                    Error::new(
-                        ErrorKind::IcebergDataInvalid,
-                        format!(
-                            "Failed to find column with id: {} in schema {:?}",
-                            id, arrow_schema
-                        ),
-                    )
-                })?;
-            unique_column_idx.push(res.0);
-        }
+        let (col_extractor, unique_col_schema) =
+            ColumnExtractor::new(&arrow_schema, &unique_column_ids)?;
 
         // Create the row converter for unique columns.
-        let unique_col_schema = arrow_schema.project(&unique_column_idx).map_err(|err| {
-            Error::new(
-                ErrorKind::ArrowError,
-                format!(
-                    "Failed to project schema with equality ids: {:?}, error: {}",
-                    unique_column_idx, err
-                ),
-            )
-        })?;
         let row_converter = RowConverter::new(
             unique_col_schema
                 .fields()
@@ -138,7 +105,7 @@ impl<L: FileAppenderLayer<DefaultFileAppender>> EqualityDeltaWriter<L> {
             ),
             inserted_rows: HashMap::new(),
             row_converter,
-            unique_column_idx,
+            col_extractor,
         })
     }
 
@@ -244,17 +211,8 @@ impl<L: FileAppenderLayer<DefaultFileAppender>> EqualityDeltaWriter<L> {
     }
 
     fn extract_unique_column(&mut self, batch: &RecordBatch) -> Result<Rows> {
-        let batch_with_unique_column = batch.project(&self.unique_column_idx).map_err(|err| {
-            Error::new(
-                ErrorKind::ArrowError,
-                format!(
-                    "Failed to project record batch with index: {:?}, error: {}",
-                    self.unique_column_idx, err
-                ),
-            )
-        })?;
         self.row_converter
-            .convert_columns(batch_with_unique_column.columns())
+            .convert_columns(&self.col_extractor.extract(batch))
             .map_err(|err| {
                 Error::new(
                     ErrorKind::ArrowError,

--- a/icelake/src/io/upsert_writer.rs
+++ b/icelake/src/io/upsert_writer.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::{
-    types::{Any, ColumnExtractor, PartitionKey},
+    types::{Any, FieldProjector, PartitionKey},
     ErrorKind, Result,
 };
 use arrow_array::{Int32Array, RecordBatch};
@@ -69,7 +69,7 @@ impl<L: FileAppenderLayer<DefaultFileAppender>> UpsertWriter<L> {
                 .iter()
                 .map(|field| field.source_column_id as usize)
                 .collect_vec();
-            let (col_extractor, _) = ColumnExtractor::new(&arrow_schema, &column_ids)?;
+            let (col_extractor, _) = FieldProjector::new(&arrow_schema, &column_ids)?;
             let partition_splitter = PartitionSplitter::try_new(
                 col_extractor,
                 current_partition_spec,

--- a/icelake/src/io/upsert_writer.rs
+++ b/icelake/src/io/upsert_writer.rs
@@ -4,11 +4,12 @@ use std::{
 };
 
 use crate::{
-    types::{Any, PartitionKey},
+    types::{Any, ColumnExtractor, PartitionKey},
     ErrorKind, Result,
 };
 use arrow_array::{Int32Array, RecordBatch};
 use arrow_schema::SchemaRef;
+use itertools::Itertools;
 
 use crate::{
     config::TableConfigRef,
@@ -63,9 +64,15 @@ impl<L: FileAppenderLayer<DefaultFileAppender>> UpsertWriter<L> {
                 .await?,
             ))
         } else {
+            let column_ids = current_partition_spec
+                .fields
+                .iter()
+                .map(|field| field.source_column_id as usize)
+                .collect_vec();
+            let (col_extractor, _) = ColumnExtractor::new(&arrow_schema, &column_ids)?;
             let partition_splitter = PartitionSplitter::try_new(
+                col_extractor,
                 current_partition_spec,
-                &arrow_schema,
                 Any::Struct(
                     current_partition_spec
                         .partition_type(current_schema)?

--- a/icelake/src/table.rs
+++ b/icelake/src/table.rs
@@ -14,7 +14,7 @@ use url::Url;
 
 use crate::config::{TableConfig, TableConfigRef};
 use crate::types::{
-    Any, ColumnExtractor, DataFile, PartitionSplitter, Schema, Snapshot, TableMetadata,
+    Any, DataFile, FieldProjector, PartitionSplitter, Schema, Snapshot, TableMetadata,
 };
 use crate::{types, Error, ErrorKind};
 
@@ -355,7 +355,7 @@ impl Table {
             .iter()
             .map(|field| field.source_column_id as usize)
             .collect_vec();
-        let (col_extractor, _) = ColumnExtractor::new(&arrow_schema, &column_ids)?;
+        let (col_extractor, _) = FieldProjector::new(&arrow_schema, &column_ids)?;
 
         let partition_type = Any::Struct(
             current_partition_spec

--- a/icelake/src/types/partition_splitter.rs
+++ b/icelake/src/types/partition_splitter.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use super::{
     create_transform_function, Any, AnyValue, BoxedTransformFunction, PartitionSpec, StructValue,
+    COLUMN_ID_META_KEY,
 };
 use crate::{types::struct_to_anyvalue_array_with_type, Error, ErrorKind, Result};
 use arrow_array::{Array, ArrayRef, BooleanArray, RecordBatch, StructArray};
@@ -9,19 +10,93 @@ use arrow_cast::cast;
 use arrow_row::{OwnedRow, RowConverter, SortField};
 use arrow_schema::{DataType, FieldRef, Fields, SchemaRef};
 use arrow_select::filter::filter_record_batch;
+use itertools::Itertools;
 
-/// `PartitionSplitter` is used to split a given record according partition value.
-pub struct PartitionSplitter {
-    field_infos: Vec<PartitionFieldComputeInfo>,
-    partition_type: Any,
-    row_converter: RowConverter,
+/// Help to extract column from RecordBatch according to the column ids.
+pub struct ColumnExtractor {
+    index_vec_vec: Vec<Vec<usize>>,
 }
 
-/// Internal info used to compute single partition field .
-struct PartitionFieldComputeInfo {
-    pub index_vec: Vec<usize>,
-    pub field: FieldRef,
-    pub transform: BoxedTransformFunction,
+impl ColumnExtractor {
+    pub fn new(batch_schema: &SchemaRef, column_ids: &[usize]) -> Result<(Self, SchemaRef)> {
+        let mut index_vec_vec = Vec::with_capacity(column_ids.len());
+        let mut fields = Vec::with_capacity(column_ids.len());
+        for &id in column_ids {
+            let mut index_vec = vec![];
+            if let Some(field) =
+                Self::fetch_column_index(batch_schema.fields(), &mut index_vec, id as i64)
+            {
+                fields.push(field.clone());
+                index_vec_vec.push(index_vec);
+            } else {
+                return Err(Error::new(
+                    ErrorKind::IcebergDataInvalid,
+                    format!("Can't find source column id: {}", id),
+                ));
+            }
+        }
+        Ok((
+            Self { index_vec_vec },
+            Arc::new(arrow_schema::Schema::new(Fields::from_iter(fields))),
+        ))
+    }
+
+    fn fetch_column_index(
+        fields: &Fields,
+        index_vec: &mut Vec<usize>,
+        col_id: i64,
+    ) -> Option<FieldRef> {
+        for (pos, field) in fields.iter().enumerate() {
+            let id: i64 = field
+                .metadata()
+                .get(COLUMN_ID_META_KEY)
+                .expect("column_id must be set")
+                .parse()
+                .expect("column_id must can be parse as i64");
+            if col_id == id {
+                index_vec.push(pos);
+                return Some(field.clone());
+            }
+            if let DataType::Struct(inner) = field.data_type() {
+                let res = Self::fetch_column_index(inner, index_vec, col_id);
+                if !index_vec.is_empty() {
+                    index_vec.push(pos);
+                    return res;
+                }
+            }
+        }
+        None
+    }
+
+    pub fn extract(&self, batch: &RecordBatch) -> Vec<ArrayRef> {
+        self.index_vec_vec
+            .iter()
+            .map(|index_vec| Self::get_column_by_index_vec(batch, index_vec))
+            .collect_vec()
+    }
+
+    fn get_column_by_index_vec(batch: &RecordBatch, index_vec: &[usize]) -> ArrayRef {
+        let mut rev_iterator = index_vec.iter().rev();
+        let mut array = batch.column(*rev_iterator.next().unwrap()).clone();
+        for idx in rev_iterator {
+            array = array
+                .as_any()
+                .downcast_ref::<StructArray>()
+                .unwrap()
+                .column(*idx)
+                .clone();
+        }
+        array
+    }
+}
+
+/// `PartitionSplitter` is used to split a given record according partition spec
+pub struct PartitionSplitter {
+    col_extractor: ColumnExtractor,
+    transforms: Vec<BoxedTransformFunction>,
+    row_converter: RowConverter,
+    arrow_partition_type_fields: Fields,
+    partition_type: Any,
 }
 
 #[derive(Hash, PartialEq, PartialOrd, Eq, Ord, Clone)]
@@ -40,88 +115,39 @@ impl PartitionSplitter {
     /// Create a new `PartitionSplitter`.
     pub fn try_new(
         partition_spec: &PartitionSpec,
-        schema: &SchemaRef,
+        batch_schema: &SchemaRef,
         partition_type: Any,
     ) -> Result<Self> {
-        let arrow_partition_type: DataType = partition_type.clone().try_into()?;
-        let row_converter = RowConverter::new(vec![SortField::new(arrow_partition_type.clone())])
-            .map_err(|e| {
-            crate::error::Error::new(crate::ErrorKind::ArrowError, format!("{}", e))
-        })?;
+        let column_ids = partition_spec
+            .fields
+            .iter()
+            .map(|field| field.source_column_id as usize)
+            .collect_vec();
+        let transforms = partition_spec
+            .fields
+            .iter()
+            .map(|field| create_transform_function(&field.transform))
+            .try_collect()?;
+        let (col_extractor, _) = ColumnExtractor::new(batch_schema, &column_ids)?;
 
-        let field_infos = if let DataType::Struct(struct_type) = arrow_partition_type {
-            if struct_type.len() != partition_spec.fields.len() {
-                return Err(Error::new(
-                    ErrorKind::IcebergDataInvalid,
-                    format!(
-                        "Partition spec fields length {} not match partition type fields length {}",
-                        partition_spec.fields.len(),
-                        struct_type.len()
-                    ),
-                ));
-            }
-            struct_type
-                .iter()
-                .zip(partition_spec.fields.iter())
-                .map(|(arrow_field, spec_field)| {
-                    let transform = create_transform_function(&spec_field.transform)?;
-                    let mut index_vec = vec![];
-                    Self::fetch_column_index(
-                        schema.fields(),
-                        &mut index_vec,
-                        spec_field.source_column_id as i64,
-                    );
-                    if index_vec.is_empty() {
-                        return Err(Error::new(
-                            ErrorKind::IcebergDataInvalid,
-                            format!(
-                                "Can't find source column id: {}",
-                                spec_field.source_column_id
-                            ),
-                        ));
-                    }
-                    Ok(PartitionFieldComputeInfo {
-                        index_vec,
-                        field: arrow_field.clone(),
-                        transform,
-                    })
-                })
-                .collect::<Result<Vec<_>>>()?
-        } else {
-            unreachable!("Partition type should be struct type")
-        };
+        let arrow_partition_type_fields =
+            if let DataType::Struct(fields) = partition_type.clone().try_into()? {
+                fields
+            } else {
+                unreachable!()
+            };
+        let row_converter = RowConverter::new(vec![SortField::new(DataType::Struct(
+            arrow_partition_type_fields.clone(),
+        ))])
+        .map_err(|e| crate::error::Error::new(crate::ErrorKind::ArrowError, format!("{}", e)))?;
+
         Ok(Self {
-            field_infos,
-            partition_type,
+            col_extractor,
+            transforms,
+            arrow_partition_type_fields,
             row_converter,
+            partition_type,
         })
-    }
-
-    /// Fetch the column index vector of the column id (We store it in Field of arrow as dict id).
-    /// e.g.
-    /// struct<struct<x:1,y:2>,z:3>
-    /// for source column id 2,
-    /// you will get the source column index vector [1,0]
-    fn fetch_column_index(fields: &Fields, index_vec: &mut Vec<usize>, col_id: i64) {
-        for (pos, field) in fields.iter().enumerate() {
-            let id: i64 = field
-                .metadata()
-                .get("column_id")
-                .expect("column_id must be set")
-                .parse()
-                .expect("column_id must can be parse as i64");
-            if col_id == id {
-                index_vec.push(pos);
-                return;
-            }
-            if let DataType::Struct(inner) = field.data_type() {
-                Self::fetch_column_index(inner, index_vec, col_id);
-                if !index_vec.is_empty() {
-                    index_vec.push(pos);
-                    return;
-                }
-            }
-        }
     }
 
     /// This function do two things:
@@ -131,38 +157,33 @@ impl PartitionSplitter {
         &mut self,
         batch: &RecordBatch,
     ) -> Result<HashMap<PartitionKey, RecordBatch>> {
-        let value_array = Arc::new(StructArray::from(
-            self.field_infos
+        let arrays = self.col_extractor.extract(batch);
+        let value_array = Arc::new(StructArray::new(
+            self.arrow_partition_type_fields.clone(),
+            arrays
                 .iter()
-                .map(
-                    |PartitionFieldComputeInfo {
-                         index_vec,
-                         field,
-                         transform,
-                     }| {
-                        let array = Self::get_column_by_index_vec(batch, index_vec);
-                        let mut array = transform.transform(array)?;
-                        // Try avoid different timestamp time zone.
-                        if array.data_type() != field.data_type() {
-                            if let DataType::Timestamp(unit, _) = array.data_type() {
-                                if let DataType::Timestamp(field_unit, _) = field.data_type() {
-                                    if unit == field_unit {
-                                        array =
-                                            cast(&transform.transform(array)?, field.data_type())
-                                                .map_err(|e| {
-                                                    crate::error::Error::new(
-                                                        crate::ErrorKind::ArrowError,
-                                                        format!("{e}"),
-                                                    )
-                                                })?
-                                    }
+                .zip(self.transforms.iter())
+                .zip(self.arrow_partition_type_fields.iter())
+                .map(|((array, transform), field)| {
+                    let mut array = transform.transform(array.clone())?;
+                    if array.data_type() != field.data_type() {
+                        if let DataType::Timestamp(unit, _) = array.data_type() {
+                            if let DataType::Timestamp(field_unit, _) = field.data_type() {
+                                if unit == field_unit {
+                                    array = cast(&array, field.data_type()).map_err(|e| {
+                                        crate::error::Error::new(
+                                            crate::ErrorKind::ArrowError,
+                                            format!("{e}"),
+                                        )
+                                    })?
                                 }
                             }
                         }
-                        Ok((field.clone(), array))
-                    },
-                )
+                    }
+                    Ok(array)
+                })
                 .collect::<Result<Vec<_>>>()?,
+            None,
         ));
 
         let rows = self
@@ -199,20 +220,6 @@ impl PartitionSplitter {
         }
 
         Ok(partition_batches)
-    }
-
-    fn get_column_by_index_vec(batch: &RecordBatch, index_vec: &[usize]) -> ArrayRef {
-        let mut rev_iterator = index_vec.iter().rev();
-        let mut array = batch.column(*rev_iterator.next().unwrap()).clone();
-        for idx in rev_iterator {
-            array = array
-                .as_any()
-                .downcast_ref::<StructArray>()
-                .unwrap()
-                .column(*idx)
-                .clone();
-        }
-        array
     }
 
     /// Convert the `PartitionKey` to `PartitionValue`

--- a/icelake/src/types/partition_splitter.rs
+++ b/icelake/src/types/partition_splitter.rs
@@ -114,21 +114,15 @@ impl From<OwnedRow> for PartitionKey {
 impl PartitionSplitter {
     /// Create a new `PartitionSplitter`.
     pub fn try_new(
+        col_extractor: ColumnExtractor,
         partition_spec: &PartitionSpec,
-        batch_schema: &SchemaRef,
         partition_type: Any,
     ) -> Result<Self> {
-        let column_ids = partition_spec
-            .fields
-            .iter()
-            .map(|field| field.source_column_id as usize)
-            .collect_vec();
         let transforms = partition_spec
             .fields
             .iter()
             .map(|field| create_transform_function(&field.transform))
             .try_collect()?;
-        let (col_extractor, _) = ColumnExtractor::new(batch_schema, &column_ids)?;
 
         let arrow_partition_type_fields =
             if let DataType::Struct(fields) = partition_type.clone().try_into()? {


### PR DESCRIPTION
Remove redundant code between EqualityDeleteWriter and PartitionSplitter.