### PR TITLE
refactor: remove async new

### DIFF
--- a/icelake/src/io/appender/mod.rs
+++ b/icelake/src/io/appender/mod.rs
@@ -127,7 +127,7 @@ impl<L: FileAppenderLayer<DefaultFileAppender>> FileAppenderBuilder<L> {
         }
     }
 
-    pub async fn build(
+    pub fn build(
         &self,
         schema: SchemaRef,
         location_generator: Arc<FileLocationGenerator>,
@@ -138,8 +138,7 @@ impl<L: FileAppenderLayer<DefaultFileAppender>> FileAppenderBuilder<L> {
             location_generator,
             schema,
             self.table_config.clone(),
-        )
-        .await?;
+        )?;
 
         Ok(self.layer.layer(inner))
     }

--- a/icelake/src/io/appender/rolling_writer.rs
+++ b/icelake/src/io/appender/rolling_writer.rs
@@ -167,6 +167,8 @@ impl RollingWriter {
 impl FileAppender for RollingWriter {
     /// Write a record batch. The `DataFileWriter` will create a new file when the current row num is greater than `target_file_row_num`.
     async fn write(&mut self, batch: RecordBatch) -> Result<()> {
+        // # TODO
+        // Optimize by `unlikely`
         if self.current_writer.is_none() {
             self.open_new_writer().await?;
         }

--- a/icelake/src/io/file_writer/data_file_writer.rs
+++ b/icelake/src/io/file_writer/data_file_writer.rs
@@ -100,8 +100,7 @@ mod test {
                 "/tmp/table".to_string(),
                 Arc::new(TableConfig::default()),
             )
-            .build(to_write.schema(), location_generator.into())
-            .await?,
+            .build(to_write.schema(), location_generator.into())?,
         )?;
 
         writer.write(to_write.clone()).await?;

--- a/icelake/src/io/file_writer/equality_delete_writer.rs
+++ b/icelake/src/io/file_writer/equality_delete_writer.rs
@@ -21,7 +21,7 @@ pub struct EqualityDeleteWriter<F: FileAppender> {
 }
 
 /// Create a new `EqualityDeleteWriter`.
-pub async fn new_eq_delete_writer<L: FileAppenderLayer<DefaultFileAppender>>(
+pub fn new_eq_delete_writer<L: FileAppenderLayer<DefaultFileAppender>>(
     arrow_schema: SchemaRef,
     equality_ids: Vec<usize>,
     location_generator: Arc<location_generator::FileLocationGenerator>,
@@ -55,7 +55,7 @@ pub async fn new_eq_delete_writer<L: FileAppenderLayer<DefaultFileAppender>>(
     })?);
 
     Ok(EqualityDeleteWriter {
-        inner_writer: factory.build(delete_schema, location_generator).await?,
+        inner_writer: factory.build(delete_schema, location_generator)?,
         equality_ids,
         col_id_idx,
     })

--- a/icelake/src/io/file_writer/position_delete_writer.rs
+++ b/icelake/src/io/file_writer/position_delete_writer.rs
@@ -68,8 +68,7 @@ impl<L: FileAppenderLayer<DefaultFileAppender>> SortedPositionDeleteWriter<L> {
     async fn flush(&mut self) -> Result<()> {
         let file_appender = self
             .file_appender_factory
-            .build(self.schema.clone(), self.location_generator.clone())
-            .await?;
+            .build(self.schema.clone(), self.location_generator.clone())?;
         let mut writer = PositionDeleteWriter::try_new(None, file_appender)?;
         let delete_cache = std::mem::take(&mut self.delete_cache);
         for (file_path, mut delete_vec) in delete_cache.into_iter() {

--- a/icelake/src/io/functional_writer/append_only_writer.rs
+++ b/icelake/src/io/functional_writer/append_only_writer.rs
@@ -35,7 +35,7 @@ pub enum AppendOnlyWriter<L: FileAppenderLayer<DefaultFileAppender>> {
 
 impl<L: FileAppenderLayer<DefaultFileAppender>> AppendOnlyWriter<L> {
     /// Create a new `TaskWriter`.
-    pub async fn try_new(
+    pub fn try_new(
         table_metadata: TableMetadata,
         file_appender_factory: FileAppenderBuilder<L>,
         location_generator: Arc<FileLocationGenerator>,
@@ -51,9 +51,7 @@ impl<L: FileAppenderLayer<DefaultFileAppender>> AppendOnlyWriter<L> {
 
         if current_partition_spec.is_unpartitioned() {
             Ok(Self::Unpartitioned(DataFileWriter::try_new(
-                file_appender_factory
-                    .build(arrow_schema, location_generator)
-                    .await?,
+                file_appender_factory.build(arrow_schema, location_generator)?,
             )?))
         } else {
             let column_ids = current_partition_spec
@@ -144,8 +142,7 @@ impl<L: FileAppenderLayer<DefaultFileAppender>> PartitionedAppendOnlyWriter<L> {
                     writer
                         .insert(DataFileWriter::try_new(
                             self.file_appender_factory
-                                .build(self.schema.clone(), self.location_generator.clone())
-                                .await?,
+                                .build(self.schema.clone(), self.location_generator.clone())?,
                         )?)
                         .write(batch)
                         .await?;

--- a/icelake/src/io/functional_writer/equality_delta_writer.rs
+++ b/icelake/src/io/functional_writer/equality_delta_writer.rs
@@ -60,7 +60,7 @@ pub struct EqDeltaWriterMetrics {
 impl<L: FileAppenderLayer<DefaultFileAppender>> EqualityDeltaWriter<L> {
     /// Create a new `EqualityDeltaWriter`.
     #[allow(clippy::too_many_arguments)]
-    pub async fn try_new(
+    pub fn try_new(
         arrow_schema: SchemaRef,
         table_config: TableConfigRef,
         unique_column_ids: Vec<usize>,
@@ -87,17 +87,14 @@ impl<L: FileAppenderLayer<DefaultFileAppender>> EqualityDeltaWriter<L> {
 
         Ok(Self {
             data_file_writer: DataFileWriter::try_new(
-                file_appender_factory
-                    .build(arrow_schema.clone(), data_location_generator)
-                    .await?,
+                file_appender_factory.build(arrow_schema.clone(), data_location_generator)?,
             )?,
             eq_delete_writer: new_eq_delete_writer(
                 arrow_schema.clone(),
                 unique_column_ids,
                 delete_location_generator.clone(),
                 &file_appender_factory,
-            )
-            .await?,
+            )?,
             sorted_pos_delete_writer: SortedPositionDeleteWriter::new(
                 table_config.clone(),
                 file_appender_factory,

--- a/icelake/src/io/writer_builder.rs
+++ b/icelake/src/io/writer_builder.rs
@@ -131,7 +131,7 @@ impl<L: FileAppenderLayer<DefaultFileAppender>> WriterBuilder<L> {
     }
 
     /// Build a `EqualityDeleteWriter`.
-    pub async fn build_equality_delete_writer(
+    pub fn build_equality_delete_writer(
         self,
         equality_ids: Vec<usize>,
     ) -> Result<EqualityDeleteWriter<L::R>> {
@@ -142,7 +142,6 @@ impl<L: FileAppenderLayer<DefaultFileAppender>> WriterBuilder<L> {
             delete_location_generator,
             &self.file_appender_builder,
         )
-        .await
     }
 
     /// Build a `EqualityDeltaWriter`.
@@ -160,23 +159,18 @@ impl<L: FileAppenderLayer<DefaultFileAppender>> WriterBuilder<L> {
             data_location_generator,
             delete_location_generator,
         )
-        .await
     }
 
-    pub async fn build_append_only_writer(self) -> Result<AppendOnlyWriter<L>> {
+    pub fn build_append_only_writer(self) -> Result<AppendOnlyWriter<L>> {
         let data_location_generator = self.data_location_generator()?.into();
         AppendOnlyWriter::try_new(
             self.table_metadata,
             self.file_appender_builder,
             data_location_generator,
         )
-        .await
     }
 
-    pub async fn build_upsert_writer(
-        self,
-        unique_column_ids: Vec<usize>,
-    ) -> Result<UpsertWriter<L>> {
+    pub fn build_upsert_writer(self, unique_column_ids: Vec<usize>) -> Result<UpsertWriter<L>> {
         let data_location_generator = self.data_location_generator()?.into();
         let delete_location_generator = self.delete_location_generator()?.into();
         UpsertWriter::try_new(
@@ -187,6 +181,5 @@ impl<L: FileAppenderLayer<DefaultFileAppender>> WriterBuilder<L> {
             data_location_generator,
             delete_location_generator,
         )
-        .await
     }
 }

--- a/icelake/tests/delta_test.rs
+++ b/icelake/tests/delta_test.rs
@@ -226,7 +226,6 @@ impl DeltaTest {
             .await
             .unwrap()
             .build_upsert_writer(vec![1, 2])
-            .await
             .unwrap();
 
         self.write_and_delete_with_delta(
@@ -291,7 +290,6 @@ impl DeltaTest {
             .await
             .unwrap()
             .build_upsert_writer(vec![1, 2])
-            .await
             .unwrap();
 
         self.write_and_delete_with_delta(
@@ -313,7 +311,6 @@ impl DeltaTest {
             .await
             .unwrap()
             .build_upsert_writer(vec![1, 2])
-            .await
             .unwrap();
 
         self.write_and_delete_with_delta(

--- a/icelake/tests/insert_compact_test.rs
+++ b/icelake/tests/insert_compact_test.rs
@@ -166,7 +166,6 @@ impl TestFixture {
                 .await
                 .unwrap()
                 .build_append_only_writer()
-                .await
                 .unwrap();
 
             for record_batch in records {

--- a/icelake/tests/insert_tests.rs
+++ b/icelake/tests/insert_tests.rs
@@ -161,7 +161,6 @@ impl TestFixture {
             .await
             .unwrap()
             .build_append_only_writer()
-            .await
             .unwrap();
 
         for record_batch in records {


### PR DESCRIPTION
I find that most of the `async new` due to the `async new` in rolling writer. We can avoid them by delay creating inner writer in rolling writer.