### PR TITLE
fix: miss field-id in serialize 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 [workspace.dependencies]
 anyhow = "1"
 async-trait = "0.1"
-apache-avro = { version = "0.15", features = ["derive"] }
+apache-avro = { git = "https://github.com/icelake-io/avro", branch = "fix_custom_attr" , features = ["derive"] }
 arrow-array = { version = ">=48" }
 arrow-schema = { version = ">=48" }
 arrow-select = { version = ">=48" }


### PR DESCRIPTION
Avro-rs is missing to serialize the custom attribute in the schema. This PR use a fork version of avro-rs to fix it first. **But it's just temporally.**
I'm keep track of the PR to fix it in upstream: https://github.com/apache/avro/pull/2650.
I will revert this PR and use the upstream version as long as the PR is merge.