### PR TITLE
build: turn off default-features for opendal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ arrow-csv = { version = ">=48" }
 arrow-cast = { version = ">=48" }
 arrow-ord = { version = ">=48" }
 bytes = "1"
-opendal = { version = ">=0.40", features = ["layers-prometheus"] }
+opendal = { version = ">=0.40", default-features = false, features = ["layers-prometheus"] }
 uuid = { version = "1", features = ["v4"] }
 serde = "1"
 serde_json = "1"

--- a/icelake/Cargo.toml
+++ b/icelake/Cargo.toml
@@ -57,6 +57,7 @@ csv = { workspace = true }
 env_logger = { workspace = true }
 arrow-csv = { workspace = true }
 libtest-mimic = { workspace = true }
+opendal = { workspace = true, features = ["services-memory", "services-fs"] }
 
 [features]
 prometheus = ["dep:prometheus"]


### PR DESCRIPTION
This forces downstream applications to use opendal default features unnecessarily.